### PR TITLE
added unit acc funding to onUpdateMarkPrice

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -168,7 +168,7 @@ interface WSMsg {
 
 ```
 // broadcasted
-// careful: openInterest and fundingRate might
+// careful: openInterest, unitAccumulatedFunding, and fundingRate might
 // be zero in which case exchangeInfo should not
 // be overwritten with 0.
 interface PriceUpdate {
@@ -178,6 +178,7 @@ interface PriceUpdate {
   indexPrice: number;
   fundingRate: number;
   openInterest: number;
+  unitAccumulatedFunding: number;
 }
 ```
 

--- a/packages/utils/src/wsTypes.ts
+++ b/packages/utils/src/wsTypes.ts
@@ -35,6 +35,7 @@ export interface PriceUpdate {
   indexPrice: number;
   fundingRate: number;
   openInterest: number;
+  unitAccumulatedFunding: number;
 }
 
 /**


### PR DESCRIPTION
Price update now contains unitAccumulatedFunding. 
interface PriceUpdate {
  perpetualId: number;
  midPrice: number;
  markPrice: number;
  indexPrice: number;
  fundingRate: number;
  openInterest: number;
  **unitAccumulatedFunding: number;**
}