### PR TITLE
Uppercase symbols

### DIFF
--- a/packages/api/src/D8XBrokerBackendApp.ts
+++ b/packages/api/src/D8XBrokerBackendApp.ts
@@ -134,7 +134,6 @@ export default class D8XBrokerBackendApp {
 						} else if (obj.type == "unsubscribe") {
 							eventListener.unsubscribe(ws, req);
 						} else {
-							console.log("received: ", obj);
 							//type = subscription
 							if (
 								typeof obj.traderAddr != "string" ||
@@ -144,6 +143,12 @@ export default class D8XBrokerBackendApp {
 									"wrong arguments. Requires traderAddr and symbol",
 								);
 							}
+
+							// Make sure the client provided symbol is
+							// in uppercase, since SDK provides uppercase
+							// symbols for perpetuals.
+							obj.symbol = obj.symbol.toUpperCase();
+
 							const perpState: PerpetualState =
 								await sdk.extractPerpetualStateFromExchangeInfo(
 									obj.symbol,

--- a/packages/api/src/indexPriceInterface.ts
+++ b/packages/api/src/indexPriceInterface.ts
@@ -101,11 +101,9 @@ export default abstract class IndexPriceInterface extends Observer {
 			for (let j = 0; j < pool.perpetuals.length; j++) {
 				const perpState: PerpetualState = pool.perpetuals[j];
 				const perpId: number = perpState.id;
-				const pxIdxName = (
-					perpState.baseCurrency +
-					"-" +
-					perpState.quoteCurrency
-				).toLowerCase();
+				// Use letter-case as it comes from the exchange info. Symbols should be
+				// in uppercase by default.
+				const pxIdxName = perpState.baseCurrency + "-" + perpState.quoteCurrency;
 				const idxs = this.idxNamesToPerpetualIds.get(pxIdxName);
 				if (idxs == undefined) {
 					const idx: number[] = [perpState.id];


### PR DESCRIPTION
This PR adds 2 changes:

1. Ignore letter case when websocket subscribes to perpetual to main ws service. Subscription query like this `{"symbol": "btc-usdc-UsdC", "traderAddr": "0xcf9a1749a574a8129f73aff40f557962cfda25cf"}` is treated the same way as `{"symbol": "BTC-USDC-USDC", "traderAddr": "0xcf9a1749a574a8129f73aff40f557962cfda25cf"}`
2. Use default (uppercase instead of lowercase) for building `idxNamesToPerpetualIds` symbol to perpetual id map in `_initIdxNamesToPerpetualIds`. `px_update`  from candles is received in uppercase, therfore `idxNamesToPerpetualIds` should also contain uppercase symbols

