### PR TITLE
Missing UpdateMarkPrice messages

### DIFF
--- a/packages/api/src/eventListener.ts
+++ b/packages/api/src/eventListener.ts
@@ -19,6 +19,7 @@ import { Contract, JsonRpcProvider } from "ethers";
 import {
 	ExecutionFailed,
 	LimitOrderCreated,
+	PerpetualStateChange,
 	PriceUpdate,
 	Trade,
 	UpdateMarginAccount,
@@ -1165,7 +1166,62 @@ export default class EventListener extends IndexPriceInterface {
 	 * @param perpetualId
 	 * @param state 'normal', 'emergency', 'settled'
 	 */
-	private onPerpetualState(perpetualId: number, state: string) {
+	private onPerpetualState(
+		perpetualId: number,
+		state: "normal" | "emergency" | "settled",
+	) {
 		this.logger.info("perpetual state changed", { perpetualId, state });
+		const symbol = this.symbolFromPerpetualId(perpetualId);
+		const obj: PerpetualStateChange = {
+			perpetualId,
+			symbol,
+			state,
+		};
+		const prices = this.lastCachedPrices(perpetualId);
+		if (prices !== undefined) {
+			obj.indexPrice = prices.indexPrice;
+			obj.markPrice = prices.markPrice;
+			obj.midPrice = prices.midPrice;
+		}
+		const wsMsg: WSMsg = { name: "PerpetualStateChange", obj };
+		const jsonMsg: string = D8XBrokerBackendApp.JSONResponse(
+			"onPerpetualStateChange",
+			"",
+			wsMsg,
+		);
+		this.sendToSubscribers(perpetualId, jsonMsg);
+	}
+
+	/**
+	 * Read the latest cached index/mark/mid for a perpl from the
+	 * IndexPriceInterface state. Returns undefined if any required component
+	 * is missing
+	 */
+	private lastCachedPrices(
+		perpetualId: number,
+	): { indexPrice: number; markPrice: number; midPrice: number } | undefined {
+		const fullSym = this.sdkInterface?.getSymbolFromPerpId(perpetualId);
+		if (fullSym === undefined) return undefined;
+		const parts = fullSym.split("-");
+		const pxIdxName = parts[0] + "-" + parts[1];
+		const currIdx = this.idxPrices.get(pxIdxName);
+		const midPrem = this.midPremium.get(perpetualId);
+		const mrkPrem = this.mrkPremium.get(perpetualId);
+		if (currIdx === undefined || midPrem === undefined) return undefined;
+		const isPred = this.isPredictionMkt.get(perpetualId) ?? false;
+		if (isPred) {
+			const idxPx = probToPrice(currIdx);
+			return {
+				indexPrice: idxPx,
+				markPrice: idxPx,
+				midPrice: Math.min(Math.max(1, idxPx + midPrem), 2),
+			};
+		}
+		if (mrkPrem === undefined) return undefined;
+		return {
+			indexPrice: currIdx,
+			markPrice: currIdx * (1 + mrkPrem),
+			midPrice: currIdx * (1 + midPrem),
+		};
 	}
 }

--- a/packages/api/src/eventListener.ts
+++ b/packages/api/src/eventListener.ts
@@ -6,7 +6,6 @@ import {
 	MASK_MARKET_ORDER,
 	NodeSDKConfig,
 	PerpetualState,
-	probToPrice,
 	SmartContractOrder,
 	TraderInterface,
 } from "@d8-x/d8x-node-sdk";
@@ -521,29 +520,52 @@ export default class EventListener extends IndexPriceInterface {
 
 		const subscribers: Map<string, WebSocket.WebSocket[]> | undefined =
 			this.subscriptions.get(perpetualId);
+		const totalWs = subscribers
+			? [...subscribers.values()].reduce((n, arr) => n + arr.length, 0)
+			: 0;
+		logger.info("sendToSubscribers", {
+			perpetualId,
+			traderAddr: traderAddr ?? "broadcast",
+			subscriberMapSize: subscribers?.size ?? 0,
+			totalWs,
+		});
 		if (subscribers == undefined) {
-			// logger.info(`no subscribers for perpetual ${perpetualId}`);
+			logger.info("sendToSubscribers: no subscribers for perpetual", {
+				perpetualId,
+				traderAddr: traderAddr ?? "broadcast",
+			});
 			return;
 		}
 		if (traderAddr != undefined) {
 			const traderWs: WebSocket[] | undefined = subscribers.get(traderAddr);
 			if (traderWs == undefined) {
-				logger.info(
-					`no subscriber to trader ${traderAddr} in perpetual ${perpetualId}`,
-				);
+				logger.info("sendToSubscribers: no subscriber for trader in perpetual", {
+					perpetualId,
+					traderAddr,
+					knownTraders: [...subscribers.keys()],
+				});
 				return;
 			}
-			// send to all subscribers of this perpetualId and traderAddress
+			logger.info("sendToSubscribers: per-trader send", {
+				perpetualId,
+				traderAddr,
+				wsCount: traderWs.length,
+			});
 			for (let k = 0; k < traderWs.length; k++) {
 				traderWs[k].send(message);
 			}
 		} else {
-			// broadcast
+			let sent = 0;
 			for (const [_trader, wsArr] of subscribers) {
 				for (let k = 0; k < wsArr.length; k++) {
 					wsArr[k].send(message);
+					sent++;
 				}
 			}
+			logger.info("sendToSubscribers: broadcast send", {
+				perpetualId,
+				sent,
+			});
 		}
 	}
 
@@ -844,68 +866,47 @@ export default class EventListener extends IndexPriceInterface {
 
 		const midPrem = ABK64x64ToFloat(fMidPricePremium);
 		const mrkPrem = ABK64x64ToFloat(fMarkPricePremium);
+		const indexPrice = ABK64x64ToFloat(fMarkIndexPrice);
 		this.midPremium.set(perpetualId, midPrem);
 		this.mrkPremium.set(perpetualId, mrkPrem);
 
-		let pxIdxName = this.sdkInterface!.getSymbolFromPerpId(perpetualId);
-		if (pxIdxName == undefined) {
-			logger.info("onUpdateMarkPrice: no index defined for perpetual", perpetualId);
-			return;
-		}
-		const parts = pxIdxName.split("-");
-		pxIdxName = parts[0] + "-" + parts[1];
-		// ensure index price availability
-		let currIdx = this.idxPrices.get(pxIdxName);
-		if (currIdx == undefined) {
-			logger.info("onUpdateMarkPrice: index name=", pxIdxName, "currIdx undefined");
-			return;
-		}
-		let newMarkPrice, newMidPrice: number;
+		let newIndexPrice: number;
+		let newMarkPrice: number;
+		let newMidPrice: number;
 		if (isPred) {
-			// for pred markets, currIdx == spot probability
-			// --> convert all to price to send over WS and update xchg info
-			// per contract: mid = index + _fCurrentPremiumRate
-			// mark = index
-			logger.info("index name=", pxIdxName, "currIdx=", currIdx);
-			currIdx = probToPrice(currIdx);
-			newMidPrice = Math.min(Math.max(1, currIdx + midPrem), 2); //clamp
-			newMarkPrice = currIdx;
+			newIndexPrice = indexPrice;
+			newMarkPrice = indexPrice;
+			newMidPrice = Math.min(Math.max(1, indexPrice + midPrem), 2);
 		} else {
-			// we don't set the index price for regular markets as this
-			// would be outdated
-			newMarkPrice = currIdx * (1 + mrkPrem);
-			newMidPrice = currIdx * (1 + midPrem);
+			newIndexPrice = indexPrice;
+			newMarkPrice = indexPrice * (1 + mrkPrem);
+			newMidPrice = indexPrice * (1 + midPrem);
 		}
-		logger.info("eventListener: onUpdateMarkPrice");
 
-		// notify websocket listeners (using prices based on most recent websocket price)
-
-		logger.info(
-			"onUpdateMarkPrice: ",
-			perpetualId,
-			"miPremium",
-			midPrem,
-			"markPrem",
-			mrkPrem,
-			"mid=",
-			newMidPrice,
-			"mark=",
-			newMarkPrice,
-			"idx=",
-			currIdx,
-		);
-		this.updateMarkPrice(perpetualId, newMidPrice, newMarkPrice, currIdx);
-
-		// update data in sdkInterface's exchangeInfo
-		const fundingRate = this.fundingRate.get(perpetualId) || 0;
-
-		const oi = this.redisOITimeSeries.get(perpetualId);
 		const symbol = this.symbolFromPerpetualId(perpetualId);
+		if (symbol !== undefined) {
+			const parts = symbol.split("-");
+			const pxIdxName = parts[0] + "-" + parts[1];
+			this.idxPrices.set(pxIdxName, isPred ? indexPrice - 1 : indexPrice);
+		}
+
+		logger.info("onUpdateMarkPrice", {
+			perpetualId,
+			midPrem,
+			mrkPrem,
+			newIndexPrice,
+			newMarkPrice,
+			newMidPrice,
+		});
+		this.updateMarkPrice(perpetualId, newMidPrice, newMarkPrice, newIndexPrice);
+
+		const fundingRate = this.fundingRate.get(perpetualId) || 0;
+		const oi = this.redisOITimeSeries.get(perpetualId);
 
 		if (this.sdkInterface != undefined && symbol != undefined) {
 			this.sdkInterface.updateExchangeInfoNumbersOfPerpetual(
 				symbol,
-				[newMidPrice, newMarkPrice, currIdx, oi, fundingRate * 1e4],
+				[newMidPrice, newMarkPrice, newIndexPrice, oi, fundingRate * 1e4],
 				[
 					"midPrice",
 					"markPrice",
@@ -1171,13 +1172,12 @@ export default class EventListener extends IndexPriceInterface {
 		state: "normal" | "emergency" | "settled",
 	) {
 		this.logger.info("perpetual state changed", { perpetualId, state });
-		const symbol = this.symbolFromPerpetualId(perpetualId);
 		const obj: PerpetualStateChange = {
 			perpetualId,
-			symbol,
+			symbol: this.symbolFromPerpetualId(perpetualId),
 			state,
 		};
-		const prices = this.lastCachedPrices(perpetualId);
+		const prices = this.getCachedPrices(perpetualId);
 		if (prices !== undefined) {
 			obj.indexPrice = prices.indexPrice;
 			obj.markPrice = prices.markPrice;
@@ -1190,38 +1190,5 @@ export default class EventListener extends IndexPriceInterface {
 			wsMsg,
 		);
 		this.sendToSubscribers(perpetualId, jsonMsg);
-	}
-
-	/**
-	 * Read the latest cached index/mark/mid for a perpl from the
-	 * IndexPriceInterface state. Returns undefined if any required component
-	 * is missing
-	 */
-	private lastCachedPrices(
-		perpetualId: number,
-	): { indexPrice: number; markPrice: number; midPrice: number } | undefined {
-		const fullSym = this.sdkInterface?.getSymbolFromPerpId(perpetualId);
-		if (fullSym === undefined) return undefined;
-		const parts = fullSym.split("-");
-		const pxIdxName = parts[0] + "-" + parts[1];
-		const currIdx = this.idxPrices.get(pxIdxName);
-		const midPrem = this.midPremium.get(perpetualId);
-		const mrkPrem = this.mrkPremium.get(perpetualId);
-		if (currIdx === undefined || midPrem === undefined) return undefined;
-		const isPred = this.isPredictionMkt.get(perpetualId) ?? false;
-		if (isPred) {
-			const idxPx = probToPrice(currIdx);
-			return {
-				indexPrice: idxPx,
-				markPrice: idxPx,
-				midPrice: Math.min(Math.max(1, idxPx + midPrem), 2),
-			};
-		}
-		if (mrkPrem === undefined) return undefined;
-		return {
-			indexPrice: currIdx,
-			markPrice: currIdx * (1 + mrkPrem),
-			midPrice: currIdx * (1 + midPrem),
-		};
 	}
 }

--- a/packages/api/src/eventListener.ts
+++ b/packages/api/src/eventListener.ts
@@ -6,6 +6,7 @@ import {
 	MASK_MARKET_ORDER,
 	NodeSDKConfig,
 	PerpetualState,
+	priceToProb,
 	SmartContractOrder,
 	TraderInterface,
 } from "@d8-x/d8x-node-sdk";
@@ -523,7 +524,7 @@ export default class EventListener extends IndexPriceInterface {
 		const totalWs = subscribers
 			? [...subscribers.values()].reduce((n, arr) => n + arr.length, 0)
 			: 0;
-		logger.info("sendToSubscribers", {
+		logger.debug("sendToSubscribers", {
 			perpetualId,
 			traderAddr: traderAddr ?? "broadcast",
 			subscriberMapSize: subscribers?.size ?? 0,
@@ -870,25 +871,20 @@ export default class EventListener extends IndexPriceInterface {
 		this.midPremium.set(perpetualId, midPrem);
 		this.mrkPremium.set(perpetualId, mrkPrem);
 
-		let newIndexPrice: number;
-		let newMarkPrice: number;
-		let newMidPrice: number;
-		if (isPred) {
-			newIndexPrice = indexPrice;
-			newMarkPrice = indexPrice;
-			newMidPrice = Math.min(Math.max(1, indexPrice + midPrem), 2);
-		} else {
-			newIndexPrice = indexPrice;
-			newMarkPrice = indexPrice * (1 + mrkPrem);
-			newMidPrice = indexPrice * (1 + midPrem);
-		}
-
+		const idxRaw = isPred ? priceToProb(indexPrice) : indexPrice;
+		this.setCachedIndex(perpetualId, idxRaw);
 		const symbol = this.symbolFromPerpetualId(perpetualId);
-		if (symbol !== undefined) {
-			const parts = symbol.split("-");
-			const pxIdxName = parts[0] + "-" + parts[1];
-			this.idxPrices.set(pxIdxName, isPred ? indexPrice - 1 : indexPrice);
+
+		const prices = this.computePrices(perpetualId, idxRaw);
+		if (prices === undefined) {
+			logger.warn("onUpdateMarkPrice: computePrices undefined", { perpetualId });
+			return;
 		}
+		const {
+			indexPrice: newIndexPrice,
+			markPrice: newMarkPrice,
+			midPrice: newMidPrice,
+		} = prices;
 
 		logger.info("onUpdateMarkPrice", {
 			perpetualId,

--- a/packages/api/src/indexPriceInterface.ts
+++ b/packages/api/src/indexPriceInterface.ts
@@ -1,4 +1,9 @@
-import { ExchangeInfo, PerpetualState, probToPrice } from "@d8-x/d8x-node-sdk";
+import {
+	ExchangeInfo,
+	PerpetualState,
+	priceToProb,
+	probToPrice,
+} from "@d8-x/d8x-node-sdk";
 import type { RedisClientType } from "redis";
 import { constructRedis, extractErrorMsg } from "utils";
 import Observer from "./observer.js";
@@ -137,7 +142,7 @@ export default abstract class IndexPriceInterface extends Observer {
 					// save prob and additive premia
 					indices[indices.length - 1] = "sport:" + indices[indices.length - 1];
 					indices.push("sport:" + pxIdxName + "|mark");
-					this.idxPrices.set(pxIdxName, px - 1);
+					this.idxPrices.set(pxIdxName, priceToProb(px));
 					this.mrkPremium.set(perpId, perpState.markPrice - px);
 					this.midPremium.set(perpId, perpState.midPrice - px);
 				} else {
@@ -226,30 +231,25 @@ export default abstract class IndexPriceInterface extends Observer {
 	}
 
 	/**
-	 * Index/mark/mid from cached values. undefined if any are missing.
+	 * derive index/mark/mid from a raw idx value
+	 * Returns undefined if the perp's metadata isn't ready.
 	 */
-	protected getCachedPrices(
+	protected computePrices(
 		perpetualId: number,
-		idxName?: string,
+		idxRaw: number,
 	): { indexPrice: number; markPrice: number; midPrice: number } | undefined {
-		const fullSym = idxName ?? this.sdkInterface?.getSymbolFromPerpId(perpetualId);
-		if (fullSym === undefined) return undefined;
-		const parts = fullSym.split("-");
-		const pxIdxName = parts[0] + "-" + parts[1];
 		const isPred = this.isPredictionMkt.get(perpetualId);
 		const markPremium = this.mrkPremium.get(perpetualId);
 		const midPremium = this.midPremium.get(perpetualId);
-		let px = this.idxPrices.get(pxIdxName);
 		if (
 			isPred === undefined ||
-			px === undefined ||
 			midPremium === undefined ||
 			(!isPred && markPremium === undefined)
 		) {
 			return undefined;
 		}
 		if (isPred) {
-			px = probToPrice(px);
+			const px = probToPrice(idxRaw);
 			return {
 				indexPrice: px,
 				markPrice: px,
@@ -257,10 +257,37 @@ export default abstract class IndexPriceInterface extends Observer {
 			};
 		}
 		return {
-			indexPrice: px,
-			markPrice: px * (1 + markPremium!),
-			midPrice: px * (1 + midPremium),
+			indexPrice: idxRaw,
+			markPrice: idxRaw * (1 + markPremium!),
+			midPrice: idxRaw * (1 + midPremium),
 		};
+	}
+
+	/**
+	 * Read the latest cached idx for a perpetual and compute prices.
+	 * for pred markets idxPrices stores the probability.
+	 */
+	protected getCachedPrices(
+		perpetualId: number,
+	): { indexPrice: number; markPrice: number; midPrice: number } | undefined {
+		const fullSym = this.sdkInterface?.getSymbolFromPerpId(perpetualId);
+		if (fullSym === undefined) return undefined;
+		const parts = fullSym.split("-");
+		const pxIdxName = parts[0] + "-" + parts[1];
+		const idxRaw = this.idxPrices.get(pxIdxName);
+		if (idxRaw === undefined) return undefined;
+		return this.computePrices(perpetualId, idxRaw);
+	}
+
+	/**
+	 * Write the latest oracle value into idxPrices.
+	 */
+	protected setCachedIndex(perpetualId: number, idxRaw: number): void {
+		const fullSym = this.sdkInterface?.getSymbolFromPerpId(perpetualId);
+		if (fullSym === undefined) return;
+		const parts = fullSym.split("-");
+		const pxIdxName = parts[0] + "-" + parts[1];
+		this.idxPrices.set(pxIdxName, idxRaw);
 	}
 
 	/**
@@ -277,8 +304,14 @@ export default abstract class IndexPriceInterface extends Observer {
 				continue;
 			}
 			for (let j = 0; j < perpetualIds.length; j++) {
-				const prices = this.getCachedPrices(perpetualIds[j], indices[k]);
-				if (prices === undefined) continue;
+				const prices = this.getCachedPrices(perpetualIds[j]);
+				if (prices === undefined) {
+					logger.debug("_updatePricesOnIndexPrice: cached prices missing", {
+						perpetualId: perpetualIds[j],
+						idx: indices[k],
+					});
+					continue;
+				}
 				this.updateMarkPrice(
 					perpetualIds[j],
 					prices.midPrice,

--- a/packages/api/src/indexPriceInterface.ts
+++ b/packages/api/src/indexPriceInterface.ts
@@ -226,6 +226,44 @@ export default abstract class IndexPriceInterface extends Observer {
 	}
 
 	/**
+	 * Index/mark/mid from cached values. undefined if any are missing.
+	 */
+	protected getCachedPrices(
+		perpetualId: number,
+		idxName?: string,
+	): { indexPrice: number; markPrice: number; midPrice: number } | undefined {
+		const fullSym = idxName ?? this.sdkInterface?.getSymbolFromPerpId(perpetualId);
+		if (fullSym === undefined) return undefined;
+		const parts = fullSym.split("-");
+		const pxIdxName = parts[0] + "-" + parts[1];
+		const isPred = this.isPredictionMkt.get(perpetualId);
+		const markPremium = this.mrkPremium.get(perpetualId);
+		const midPremium = this.midPremium.get(perpetualId);
+		let px = this.idxPrices.get(pxIdxName);
+		if (
+			isPred === undefined ||
+			px === undefined ||
+			midPremium === undefined ||
+			(!isPred && markPremium === undefined)
+		) {
+			return undefined;
+		}
+		if (isPred) {
+			px = probToPrice(px);
+			return {
+				indexPrice: px,
+				markPrice: px,
+				midPrice: Math.min(Math.max(1, px + midPremium), 2),
+			};
+		}
+		return {
+			indexPrice: px,
+			markPrice: px * (1 + markPremium!),
+			midPrice: px * (1 + midPremium),
+		};
+	}
+
+	/**
 	 * Upon receipt of new index prices, the index prices are factored into
 	 * mid-price and mark-price and the 3 prices are sent to ws-subscribers
 	 * @param indices index names, such as BTC-USDC
@@ -238,42 +276,15 @@ export default abstract class IndexPriceInterface extends Observer {
 			if (perpetualIds == undefined) {
 				continue;
 			}
-			let px = this.idxPrices.get(indices[k]);
 			for (let j = 0; j < perpetualIds.length; j++) {
-				const isPred = this.isPredictionMkt.get(perpetualIds[j]);
-				const markPremium = this.mrkPremium.get(perpetualIds[j]);
-				const midPremium = this.midPremium.get(perpetualIds[j]);
-				if (isPred === undefined) {
-					logger.error(
-						"perpetualId missing from isPredictionMkt. Restarting to refresh mapping",
-						{
-							perpetualId: perpetualIds[j],
-						},
-					);
-					process.exit(1);
-				}
-				if (
-					px == undefined ||
-					markPremium == undefined ||
-					midPremium == undefined
-				) {
-					continue;
-				}
-				let midPx, markPx: number;
-				if (isPred) {
-					// for pred markets, px and emaPrices are probabilities (set by candles)
-					px = probToPrice(px);
-					// per contract: mid = index + additive premium (clamped),
-					// mark = index (no premium)
-					midPx = Math.min(Math.max(1, px + midPremium), 2);
-					markPx = px;
-				} else {
-					// premia are relative
-					midPx = px * (1 + midPremium);
-					markPx = px * (1 + markPremium);
-				}
-				// call update to inform websocket
-				this.updateMarkPrice(perpetualIds[j], midPx, markPx!, px!);
+				const prices = this.getCachedPrices(perpetualIds[j], indices[k]);
+				if (prices === undefined) continue;
+				this.updateMarkPrice(
+					perpetualIds[j],
+					prices.midPrice,
+					prices.markPrice,
+					prices.indexPrice,
+				);
 			}
 		}
 	}

--- a/packages/utils/src/wsTypes.ts
+++ b/packages/utils/src/wsTypes.ts
@@ -107,16 +107,6 @@ export interface MarginAccount {
 
 /**
  * Emitted when a perpetual transitions to a non-trading lifecycle state.
- *
- * The three values map to contract events, NOT to the full SDK lifecycle
- * enum (INVALID/INITIALIZING/NORMAL/EMERGENCY/SETTLE/CLEARED):
- *  - "normal"    → SetNormalState
- *  - "emergency" → SetEmergencyState
- *  - "settled"   → SettlementComplete (i.e. SDK state CLEARED, not SETTLE)
- *
- * indexPrice / markPrice / midPrice are populated when the cached prices
- * are available; they may be omitted if the perpetual hasn't received an
- * index/premium update yet.
  */
 export interface PerpetualStateChange {
 	perpetualId: number;

--- a/packages/utils/src/wsTypes.ts
+++ b/packages/utils/src/wsTypes.ts
@@ -106,6 +106,19 @@ export interface MarginAccount {
  */
 
 /**
+ * Emitted when a perpetual transitions between
+ * NORMAL / EMERGENCY / SETTLED states.
+ */
+export interface PerpetualStateChange {
+	perpetualId: number;
+	symbol: string;
+	state: "normal" | "emergency" | "settled";
+	indexPrice?: number;
+	markPrice?: number;
+	midPrice?: number;
+}
+
+/**
  * This event message is generated on
  * UpdateMarginAccount
  * You may want to call positionRisk

--- a/packages/utils/src/wsTypes.ts
+++ b/packages/utils/src/wsTypes.ts
@@ -107,6 +107,7 @@ export interface MarginAccount {
 
 /**
  * Emitted when a perpetual transitions to a non-trading lifecycle state.
+ * indexPrice / markPrice / midPrice are populated when the cached prices are available
  */
 export interface PerpetualStateChange {
 	perpetualId: number;

--- a/packages/utils/src/wsTypes.ts
+++ b/packages/utils/src/wsTypes.ts
@@ -106,8 +106,17 @@ export interface MarginAccount {
  */
 
 /**
- * Emitted when a perpetual transitions between
- * NORMAL / EMERGENCY / SETTLED states.
+ * Emitted when a perpetual transitions to a non-trading lifecycle state.
+ *
+ * The three values map to contract events, NOT to the full SDK lifecycle
+ * enum (INVALID/INITIALIZING/NORMAL/EMERGENCY/SETTLE/CLEARED):
+ *  - "normal"    → SetNormalState
+ *  - "emergency" → SetEmergencyState
+ *  - "settled"   → SettlementComplete (i.e. SDK state CLEARED, not SETTLE)
+ *
+ * indexPrice / markPrice / midPrice are populated when the cached prices
+ * are available; they may be omitted if the perpetual hasn't received an
+ * index/premium update yet.
  */
 export interface PerpetualStateChange {
 	perpetualId: number;


### PR DESCRIPTION
### Problem with the UpdateMarkPrice: 
------
#### During NORMAL: 

**Problem:** Subscriber never receives the onUpdateMarkPrice 


**Symptoms:**

The backend logs show :

```
stack_api.1.mquc5i2x0xdi@worker-02    | {"level":"info","message":"onTrade 0x7F8E3a97679Cdb87f38CAaA63753196485b509aD Market Order in perpetual 100014","service":"api","timestamp":"2026-05-01T09:40:43.124Z"}
-->> stack_api.1.mquc5i2x0xdi@worker-02    | {"level":"info","message":"onUpdateMarkPrice: index name=","service":"api","timestamp":"2026-05-01T09:40:43.125Z"} <----- HERE
stack_api.1.mquc5i2x0xdi@worker-02    | {"level":"info","message":"received UpdateMarginAccount","perpetualId":100014,"service":"api","timestamp":"2026-05-01T09:40:43.396Z","trader":"0x38c4E93bac87b2fb96931dAB876Bb683D388f1A8"}
stack_api.1.mquc5i2x0xdi@worke
```

Backend enters in: 

  let currIdx = this.idxPrices.get(pxIdxName);
  if (currIdx == undefined) {
      logger.info("onUpdateMarkPrice: index name=", pxIdxName, "currIdx undefined");
      return;   // <- EXISTS HERE 
  }

`currIdx === undefined` means the entry for that perp's BASEQUOTE key isn't in `this.idxPrices` at the moment the chain event arrives.

`idxPrices` gets populated at startup (on refreshIndexNames) or on `fetchIndicesFromRedis` wwich runs on every redis tick from candles

**Fix** Make `onUpdateMarkPrice` read the index price from the chain event itself instead of looking it up in the idxPrices cache since it had the event in hand

-----------
#### When Perp is no longer NORMAL: 
 
**Problem:**  

The `onPerpetualStateChange` does only log but never forwards anything to the frontent. 

The contract emits `UpdateMarkPrice` only while state == NORMAL. when perp transitions to EMERGENCY/SETTLED, the chain no longer emits UpdateMarkPrice. UpdateMarkPrice events stop arriving at the client.

The frontend has options to query a perp's state (slots-info, getPerpetualState, exchangeInfo), but none of them push a notification when the state actually changes. So during the live NORMAL the frontend gets onUpdateMarkPrice over WS then it just get quite when game ends. The frontend keeps showing whatever the last mark was, with no way to know the perp settled until it next polls.

**Fix:**  Make the onPerpetualStateChange broadcast to all WS clients subscribed to that perp id the state change.
