### PR TITLE
History nonarchive

### DIFF
--- a/packages/history/src/svc/deploymentBlock.test.ts
+++ b/packages/history/src/svc/deploymentBlock.test.ts
@@ -1,0 +1,106 @@
+// Quick console test for getCloseDeploymentBlock logic.
+// Usage: npx tsx packages/history/src/svc/deploymentBlock.test.ts [RPC_URL]
+//
+// Default RPC is the public Base mainnet endpoint.
+// Example:
+//   npx tsx packages/history/src/svc/deploymentBlock.test.ts https://mainnet.base.org
+
+import { JsonRpcProvider } from "ethers";
+import {
+	isNoHistoricalStateError,
+	isRateLimitError,
+	formatErrorMessage,
+} from "../utils/errors.js";
+
+const CONTRACT = "0x38c4E93bac87b2fb96931dAB876Bb683D388f1A8";
+const DEFAULT_RPC = "https://mainnet.base.org";
+
+async function getCodeAt(
+	contractAddress: string,
+	blockNumber: number,
+	provider: JsonRpcProvider,
+): Promise<string> {
+	let consecutiveErrors = 0;
+	for (;;) {
+		try {
+			return await provider.getCode(contractAddress, blockNumber);
+		} catch (err) {
+			if (isNoHistoricalStateError(err)) {
+				throw new Error(
+					`RPC node is not an archive node (no historical state at block ${blockNumber}). Use an archive-capable RPC endpoint.`,
+				);
+			}
+			consecutiveErrors++;
+			if (consecutiveErrors > 10) {
+				throw new Error(
+					`getCodeAt: giving up after ${consecutiveErrors} errors: ${formatErrorMessage(err)}`,
+				);
+			}
+			const wait = isRateLimitError(err)
+				? Math.min(Math.pow(2, consecutiveErrors) * 2, 120)
+				: Math.min(consecutiveErrors * 10, 120);
+			console.warn(
+				`getCodeAt: ${isRateLimitError(err) ? "rate limited" : "error"}, waiting ${wait}s (attempt ${consecutiveErrors})`,
+			);
+			await new Promise((r) => setTimeout(r, wait * 1000));
+		}
+	}
+}
+
+async function findDeploymentBlock(
+	contractAddress: string,
+	provider: JsonRpcProvider,
+): Promise<{ blockNumber: number; timestamp: number }> {
+	const currentBlock = await provider.getBlockNumber();
+	console.log(`Current block: ${currentBlock}`);
+
+	let upper = currentBlock - 1000;
+	let step = 10_000;
+	let lower = upper - step;
+
+	console.log(`Walking backwards from block ${upper} in steps of ${step}...`);
+	while (lower > 0) {
+		const code = await getCodeAt(contractAddress, lower, provider);
+		console.log(
+			`  block ${lower}: ${code === "0x" ? "not deployed" : "deployed"} (step=${step})`,
+		);
+		if (code === "0x") break;
+		upper = lower;
+		step = Math.min(step * 2, 2_000_000);
+		lower = Math.max(0, upper - step);
+	}
+
+	console.log(`\nBinary searching between blocks ${lower} and ${upper}...`);
+	while (upper - lower > 1) {
+		const mid = lower + Math.floor((upper - lower) / 2);
+		const code = await getCodeAt(contractAddress, mid, provider);
+		console.log(
+			`  mid=${mid}: ${code === "0x" ? "not deployed" : "deployed"} [${lower}..${upper}]`,
+		);
+		if (code === "0x") {
+			lower = mid;
+		} else {
+			upper = mid;
+		}
+	}
+
+	const block = await provider.getBlock(lower);
+	return { blockNumber: lower, timestamp: block!.timestamp };
+}
+
+async function main() {
+	const rpcUrl = process.argv[2] ?? DEFAULT_RPC;
+	console.log(`RPC:      ${rpcUrl}`);
+	console.log(`Contract: ${CONTRACT}\n`);
+
+	const provider = new JsonRpcProvider(rpcUrl);
+
+	const { blockNumber, timestamp } = await findDeploymentBlock(CONTRACT, provider);
+	const date = new Date(timestamp * 1000).toISOString();
+	console.log(`\nDeployment block: ${blockNumber} (${date})`);
+}
+
+main().catch((err) => {
+	console.error(err.message);
+	process.exit(1);
+});

--- a/packages/history/src/svc/main.ts
+++ b/packages/history/src/svc/main.ts
@@ -2,7 +2,11 @@ import { EventListener } from "../contracts/listeners.js";
 import * as dotenv from "dotenv";
 import { chooseRandomRPC, executeWithTimeout, loadConfigRPC } from "utils";
 import { logger } from "./logger.js";
-import { isRateLimitError, formatErrorMessage } from "../utils/errors.js";
+import {
+	isRateLimitError,
+	isNoHistoricalStateError,
+	formatErrorMessage,
+} from "../utils/errors.js";
 import { JsonRpcProvider, Network, WebSocketProvider, ethers } from "ethers";
 import { ListeningMode } from "../contracts/types.js";
 import { PrismaClient } from "@prisma/client";
@@ -359,25 +363,27 @@ export const main = async () => {
 	api.start(httpRpcUrl, staticInfo.sdkState);
 };
 
-//getCloseDeploymentBlock finds a block that is a few blocks before the proxy contract
-//was deployed.
-async function getCloseDeploymentBlock(
+async function getCodeAt(
 	contractAddress: string,
+	blockNumber: number,
 	provider: ethers.Provider,
-): Promise<{ blockNumber: number; timestamp: number }> {
-	let blockNumber = await provider.getBlockNumber();
-	const delta = 1000;
-	blockNumber = blockNumber - delta;
-	let lastAvailBlock = blockNumber;
-	let lastNABlock = 0;
-	let code: string;
+): Promise<string> {
 	let consecutiveErrors = 0;
-	while (lastAvailBlock - lastNABlock > 10_000) {
+	for (;;) {
 		try {
-			code = await provider.getCode(contractAddress, blockNumber);
-			consecutiveErrors = 0;
+			return await provider.getCode(contractAddress, blockNumber);
 		} catch (err) {
+			if (isNoHistoricalStateError(err)) {
+				throw new Error(
+					`RPC node is not an archive node (no historical state at block ${blockNumber}). Use an archive-capable RPC endpoint.`,
+				);
+			}
 			consecutiveErrors++;
+			if (consecutiveErrors > 10) {
+				throw new Error(
+					`getCodeAt: giving up after ${consecutiveErrors} errors at block ${blockNumber}: ${formatErrorMessage(err)}`,
+				);
+			}
 			const wait = isRateLimitError(err)
 				? Math.min(Math.pow(2, consecutiveErrors) * 2, 120)
 				: Math.min(consecutiveErrors * 10, 120);
@@ -386,23 +392,51 @@ async function getCloseDeploymentBlock(
 				metrics.lastRateLimitAt = new Date().toISOString();
 			}
 			logger.warn(
-				`getCloseDeploymentBlock: ${isRateLimitError(err) ? "rate limited" : "error"}, waiting ${wait}s (attempt ${consecutiveErrors})`,
-				{ error: formatErrorMessage(err) },
+				`getCodeAt: ${isRateLimitError(err) ? "rate limited" : "error"}, waiting ${wait}s`,
+				{
+					blockNumber,
+					attempt: consecutiveErrors,
+					error: formatErrorMessage(err),
+				},
 			);
 			await sleepForSec(wait);
-			continue;
 		}
-		if (code === "0x") {
-			lastNABlock = blockNumber;
-		} else {
-			lastAvailBlock = blockNumber;
-		}
-		blockNumber = lastNABlock + Math.floor((lastAvailBlock - lastNABlock) / 2);
 	}
-	const block = await provider.getBlock(lastNABlock);
+}
 
-	return {
-		blockNumber: lastNABlock,
-		timestamp: block!.timestamp,
-	};
+// Walk backwards from the current block in exponentially growing steps until
+// getCode returns "0x" (contract not yet deployed), then binary-search the
+// exact boundary. Throws immediately if the node lacks archive state.
+async function getCloseDeploymentBlock(
+	contractAddress: string,
+	provider: ethers.Provider,
+): Promise<{ blockNumber: number; timestamp: number }> {
+	const currentBlock = await provider.getBlockNumber();
+
+	let upper = currentBlock - 1000;
+	let step = 10_000;
+	let lower = upper - step;
+
+	// Walk back until we find a block where the contract doesn't exist yet.
+	while (lower > 0) {
+		const code = await getCodeAt(contractAddress, lower, provider);
+		if (code === "0x") break;
+		upper = lower;
+		step = Math.min(step * 2, 2_000_000);
+		lower = Math.max(0, upper - step);
+	}
+
+	// Binary search the deployment boundary between lower ("0x") and upper (bytecode).
+	while (upper - lower > 1) {
+		const mid = lower + Math.floor((upper - lower) / 2);
+		const code = await getCodeAt(contractAddress, mid, provider);
+		if (code === "0x") {
+			lower = mid;
+		} else {
+			upper = mid;
+		}
+	}
+
+	const block = await provider.getBlock(lower);
+	return { blockNumber: lower, timestamp: block!.timestamp };
 }

--- a/packages/history/src/utils/errors.ts
+++ b/packages/history/src/utils/errors.ts
@@ -11,6 +11,11 @@ interface RpcErrorShape {
 	};
 }
 
+export function isNoHistoricalStateError(error: unknown): boolean {
+	const msg = formatErrorMessage(error);
+	return msg.includes("historical state") && msg.includes("is not available");
+}
+
 export function isRateLimitError(error: unknown): boolean {
 	const msg = formatErrorMessage(error);
 	if (
@@ -18,8 +23,7 @@ export function isRateLimitError(error: unknown): boolean {
 		msg.includes("request limit") ||
 		msg.includes("-32016") ||
 		msg.includes("-32007") ||
-		msg.includes("429") ||
-		msg.includes("could not coalesce error")
+		msg.includes("429")
 	) {
 		return true;
 	}


### PR DESCRIPTION
### **Fix: history service stuck in infinite retry loop on non-archive RPC nodes**

**Problem**
The history service was hanging indefinitely at startup when pointed at a non-archive RPC node. The root cause was a combination of two bugs in getCloseDeploymentBlock:

**Misclassified error:** isRateLimitError matched any error containing "could not coalesce error" — which is ethers.js's generic wrapper for any RPC error. The -32000 "historical state is not available" response (returned when a node lacks archive state for a queried block) was being caught by this check and treated as a transient rate-limit error, triggering exponential backoff and infinite retries.

Unbounded binary search from block 0: getCloseDeploymentBlock ran a binary search **between block 0 and the current block.** On a non-archive node, or a node with less history, queries for old blocks all returned the misclassified error above, so the search never made progress; it just retried the same blocks forever with growing wait times.

### **Changes**
_packages/history/src/utils/errors.ts_

- Added isNoHistoricalStateError() to explicitly detect -32000 "historical state ... is not available" errors from RPC nodes.
- Removed msg.includes("could not coalesce error") from isRateLimitError(). This string is ethers.js's generic RPC error wrapper and is not a rate-limit indicator. 

_packages/history/src/svc/main.ts_

- Replaced getCloseDeploymentBlock with an approach that walks backwards from the current block in exponentially growing steps until getCode returns "0x" (contract not yet deployed), then binary-searches the exact boundary.
- The getCodeAt helper centralises retry logic and fails immediately on isNoHistoricalStateError ("RPC node is not an archive node… use an archive-capable endpoint") instead of retrying forever.
- Rate-limit errors still use exponential backoff, but give up after 10 consecutive failures.
packages/history/src/svc/deploymentBlock.test.ts

**Test**
- Runnable console script to manually test the deployment block search against any RPC and contract address.
Usage: npx tsx packages/history/src/svc/deploymentBlock.test.ts [RPC_URL]