### PR TITLE
Fix executionfailed perpetualid type

### DIFF
--- a/packages/api/src/eventListener.ts
+++ b/packages/api/src/eventListener.ts
@@ -732,6 +732,7 @@ export default class EventListener extends IndexPriceInterface {
 	 * @param fFundingRate
 	 */
 	private onUpdateFundingRate(perpetualId: number, fFundingRate: bigint) {
+		perpetualId = Number(perpetualId);
 		this.lastBlockChainEventTs = Date.now();
 		const rate = ABK64x64ToFloat(fFundingRate);
 		this.fundingRate.set(perpetualId, rate);

--- a/packages/api/src/eventListener.ts
+++ b/packages/api/src/eventListener.ts
@@ -1213,6 +1213,7 @@ export default class EventListener extends IndexPriceInterface {
 	 * @param state 'normal', 'emergency', 'settled'
 	 */
 	private onPerpetualState(perpetualId: number, state: string) {
+		perpetualId = Number(perpetualId);
 		this.logger.info("perpetual state changed", { perpetualId, state });
 	}
 }

--- a/packages/api/src/eventListener.ts
+++ b/packages/api/src/eventListener.ts
@@ -785,6 +785,7 @@ export default class EventListener extends IndexPriceInterface {
 		trader: string,
 		amount: bigint,
 	) {
+		perpetualId = Number(perpetualId);
 		this.lastBlockChainEventTs = Date.now();
 		const symbol = this.sdkInterface!.getSymbolFromPerpId(perpetualId)!;
 		const positions = <MarginAccount[]>(

--- a/packages/api/src/eventListener.ts
+++ b/packages/api/src/eventListener.ts
@@ -1024,6 +1024,7 @@ export default class EventListener extends IndexPriceInterface {
 		newPositionSizeBC: bigint,
 		price: bigint,
 	) {
+		perpetualId = Number(perpetualId);
 		const isMarketOrder = containsFlag(BigInt(order.flags), MASK_MARKET_ORDER);
 		if (isMarketOrder) {
 			this.mktOrderFrequency.executedCount += 1;

--- a/packages/api/src/eventListener.ts
+++ b/packages/api/src/eventListener.ts
@@ -349,7 +349,7 @@ export default class EventListener extends IndexPriceInterface {
 	}
 
 	private symbolFromPerpetualId(perpetualId: number): string {
-		const symbol = this.traderInterface.getSymbolFromPerpId(perpetualId);
+		const symbol = this.traderInterface.getSymbolFromPerpId(Number(perpetualId));
 		return symbol || "";
 	}
 
@@ -526,6 +526,7 @@ export default class EventListener extends IndexPriceInterface {
 	 * @param traderAddr optional: only send to this trader. Otherwise broadcast
 	 */
 	private sendToSubscribers(perpetualId: number, message: string, traderAddr?: string) {
+		perpetualId = Number(perpetualId);
 		const subscribers: Map<string, WebSocket.WebSocket[]> | undefined =
 			this.subscriptions.get(perpetualId);
 		if (subscribers == undefined) {
@@ -1107,6 +1108,7 @@ export default class EventListener extends IndexPriceInterface {
 		order: SmartContractOrder,
 		digest: string,
 	): void {
+		perpetualId = Number(perpetualId);
 		this.lastBlockChainEventTs = Date.now();
 		const isMarketOrder = containsFlag(BigInt(order.flags), MASK_MARKET_ORDER);
 		if (isMarketOrder) {
@@ -1177,6 +1179,7 @@ export default class EventListener extends IndexPriceInterface {
 		digest: string,
 		reason: string,
 	) {
+		perpetualId = Number(perpetualId);
 		this.lastBlockChainEventTs = Date.now();
 		if (!this.grantEventControlPassage(digest, "onExecutionFailed")) {
 			logger.info("onExecutionFailed duplicate");


### PR DESCRIPTION
the backend keeps the list of "which client is watching which perp", stored by perp id as a **number**. The onchain events give that id as **`bigint`**, so the lookup never matches and then the bakcend drops the event instead of sending it.

It affected every event routed by perp id. All of `ExecutionFailed`, `Trade`, `PerpetualLimitOrderCreated`, and the margin and funding updates. Only `ExecutionFailed` was noticeable, because the others are already covered by the frontend reloading data over normal HTTP, while `ExecutionFailed` has no such backup
