### PR TITLE
re-register orderbook listeners on resubscribe

### DIFF
--- a/packages/api/src/eventListener.ts
+++ b/packages/api/src/eventListener.ts
@@ -465,6 +465,7 @@ export default class EventListener extends IndexPriceInterface {
 			if (this.subscriptions.get(id)?.size == 0) {
 				released.push(id);
 				this.removeOrderBookEventHandlers(clientSubscriptions[k].symbol);
+				this.subscriptions.delete(id);
 			}
 		}
 		return released;


### PR DESCRIPTION
When the last client unsubscribes from a perpetual, the backend removes its orderbook listeners but leaves an empty entry in the `subscriptions` map. 
Since `subscribe` only reregisters listeners when the entry is missing (`if (this.subscriptions.get(id) == undefined)`), a new subscriber finds the leftover empty map and the listeners are never readded, so that perp silently stops delivering `ExecutionFailed` and `PerpetualLimitOrderCreated`. 

**simple fix** is to just delete the entry when it empties too so the next `subscribe` reregisters the listeners.

The other events (Trade, UpdateMarkPrice, UpdateMarginAccount, UpdateFundingRate...)  are not affected because they are registered once on the proxy contract in `addProxyEventHandlers`, which is global and not touched by the subscribe and unsubs. 