### PR TITLE
Add ws integration/unit tests

### DIFF
--- a/.github/workflows/ws-tests.yml
+++ b/.github/workflows/ws-tests.yml
@@ -56,6 +56,7 @@ jobs:
           check_name: WS test report
           detailed_summary: true
           include_passed: true
+          group_suite: true
           comment: true
           updateComment: true
           fail_on_failure: true

--- a/.github/workflows/ws-tests.yml
+++ b/.github/workflows/ws-tests.yml
@@ -1,0 +1,34 @@
+name: WS tests
+
+on:
+  pull_request:
+    types: [opened, reopened]
+    paths:
+      - "packages/api/src/eventListener.ts"
+      - "packages/api/src/D8XBrokerBackendApp.ts"
+      - "packages/api/src/indexPriceInterface.ts"
+      - "packages/api/src/sdkInterface.ts"
+      - "packages/api/test/**"
+
+jobs:
+  ws-tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://npm.pkg.github.com
+      - run: yarn install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: yarn workspace utils run build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: yarn workspace api run build
+      - run: yarn workspace api run test:ws
+        env:
+          WS_URL_TESTNET: ${{ vars.WS_URL_TESTNET }}
+          API_URL_TESTNET: ${{ vars.API_URL_TESTNET }}
+          WS_TEST_ORIGIN: ${{ vars.WS_TEST_ORIGIN }}
+          REDIS_URL: redis://localhost:6379

--- a/.github/workflows/ws-tests.yml
+++ b/.github/workflows/ws-tests.yml
@@ -27,10 +27,28 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: yarn workspace api run build
-      - run: yarn workspace api run test:unit
-      - run: yarn workspace api run test:ws
+
+      - name: Unit tests
+        working-directory: packages/api
+        continue-on-error: true
+        run: node --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=unit-report.xml test/unit/
+
+      - name: Integration tests
+        working-directory: packages/api
+        continue-on-error: true
         env:
           WS_URL_TESTNET: ${{ vars.WS_URL_TESTNET }}
           WS_TEST_ORIGIN: ${{ vars.WS_TEST_ORIGIN }}
           GAME_MAPPER_URL: ${{ vars.GAME_MAPPER_URL }}
           GAME_MAPPER_API_KEY: ${{ secrets.GAME_MAPPER_API_KEY }}
+        run: node --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=integration-report.xml test/ws.integration.test.mjs
+
+      - name: Test report
+        if: always()
+        uses: mikepenz/action-junit-report@v5
+        with:
+          report_paths: "packages/api/*-report.xml"
+          check_name: WS test report
+          detailed_summary: true
+          include_passed: true
+          fail_on_failure: true

--- a/.github/workflows/ws-tests.yml
+++ b/.github/workflows/ws-tests.yml
@@ -14,6 +14,10 @@ on:
 jobs:
   ws-tests:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -51,4 +55,6 @@ jobs:
           check_name: WS test report
           detailed_summary: true
           include_passed: true
+          comment: true
+          updateComment: true
           fail_on_failure: true

--- a/.github/workflows/ws-tests.yml
+++ b/.github/workflows/ws-tests.yml
@@ -31,5 +31,6 @@ jobs:
       - run: yarn workspace api run test:ws
         env:
           WS_URL_TESTNET: ${{ vars.WS_URL_TESTNET }}
-          API_URL_TESTNET: ${{ vars.API_URL_TESTNET }}
           WS_TEST_ORIGIN: ${{ vars.WS_TEST_ORIGIN }}
+          GAME_MAPPER_URL: ${{ vars.GAME_MAPPER_URL }}
+          GAME_MAPPER_API_KEY: ${{ secrets.GAME_MAPPER_API_KEY }}

--- a/.github/workflows/ws-tests.yml
+++ b/.github/workflows/ws-tests.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      packages: read
       checks: write
       pull-requests: write
     steps:

--- a/.github/workflows/ws-tests.yml
+++ b/.github/workflows/ws-tests.yml
@@ -1,6 +1,7 @@
 name: WS tests
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, reopened]
     paths:

--- a/.github/workflows/ws-tests.yml
+++ b/.github/workflows/ws-tests.yml
@@ -42,9 +42,9 @@ jobs:
         working-directory: packages/api
         continue-on-error: true
         env:
-          WS_URL_TESTNET: ${{ vars.WS_URL_TESTNET }}
+          WS_URL_TESTNET: ${{ secrets.WS_URL_TESTNET }}
           WS_TEST_ORIGIN: ${{ vars.WS_TEST_ORIGIN }}
-          GAME_MAPPER_URL: ${{ vars.GAME_MAPPER_URL }}
+          GAME_MAPPER_URL: ${{ secrets.GAME_MAPPER_URL }}
           GAME_MAPPER_API_KEY: ${{ secrets.GAME_MAPPER_API_KEY }}
         run: node --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=integration-report.xml test/ws.integration.test.mjs
 

--- a/.github/workflows/ws-tests.yml
+++ b/.github/workflows/ws-tests.yml
@@ -27,9 +27,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: yarn workspace api run build
+      - run: yarn workspace api run test:unit
       - run: yarn workspace api run test:ws
         env:
           WS_URL_TESTNET: ${{ vars.WS_URL_TESTNET }}
           API_URL_TESTNET: ${{ vars.API_URL_TESTNET }}
           WS_TEST_ORIGIN: ${{ vars.WS_TEST_ORIGIN }}
-          REDIS_URL: redis://localhost:6379

--- a/.github/workflows/ws-tests.yml
+++ b/.github/workflows/ws-tests.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Test report
         if: always()
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@v6
         with:
           report_paths: "packages/api/*-report.xml"
           check_name: WS test report

--- a/.github/workflows/ws-tests.yml
+++ b/.github/workflows/ws-tests.yml
@@ -3,7 +3,7 @@ name: WS tests
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
     paths:
       - "packages/api/src/eventListener.ts"
       - "packages/api/src/D8XBrokerBackendApp.ts"

--- a/.github/workflows/ws-trade-events-weekly.yml
+++ b/.github/workflows/ws-trade-events-weekly.yml
@@ -19,7 +19,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: yarn workspace api run test:ws:trade
         env:
-          WS_URL_TESTNET: ${{ vars.WS_URL_TESTNET }}
+          WS_URL_TESTNET: ${{ secrets.WS_URL_TESTNET }}
           RPC_TESTNET: ${{ vars.RPC_TESTNET }}
           WS_TEST_ORIGIN: ${{ vars.WS_TEST_ORIGIN }}
           KEY: ${{ secrets.KEY }}

--- a/.github/workflows/ws-trade-events-weekly.yml
+++ b/.github/workflows/ws-trade-events-weekly.yml
@@ -1,0 +1,27 @@
+name: WS trade events (weekly)
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  trade-events:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://npm.pkg.github.com
+      - run: yarn install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: yarn workspace api run test:ws:trade
+        env:
+          WS_URL_TESTNET: ${{ vars.WS_URL_TESTNET }}
+          API_URL_TESTNET: ${{ vars.API_URL_TESTNET }}
+          RPC_TESTNET: ${{ vars.RPC_TESTNET }}
+          WS_TEST_ORIGIN: ${{ vars.WS_TEST_ORIGIN }}
+          TRADE_QTY: ${{ vars.TRADE_QTY }}
+          KEY: ${{ secrets.KEY }}

--- a/.github/workflows/ws-trade-events-weekly.yml
+++ b/.github/workflows/ws-trade-events-weekly.yml
@@ -20,8 +20,6 @@ jobs:
       - run: yarn workspace api run test:ws:trade
         env:
           WS_URL_TESTNET: ${{ vars.WS_URL_TESTNET }}
-          API_URL_TESTNET: ${{ vars.API_URL_TESTNET }}
           RPC_TESTNET: ${{ vars.RPC_TESTNET }}
           WS_TEST_ORIGIN: ${{ vars.WS_TEST_ORIGIN }}
-          TRADE_QTY: ${{ vars.TRADE_QTY }}
           KEY: ${{ secrets.KEY }}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -21,7 +21,8 @@
 	"scripts": {
 		"build": "rimraf ./dist && tsc",
 		"watch": "nodemon ./src/index.ts",
-		"test:ws": "node --test test/ws.integration.test.mjs test/ws.relay.test.mjs",
+		"test:unit": "node --test test/unit/",
+		"test:ws": "node --test test/ws.integration.test.mjs",
 		"test:ws:trade": "node --test test/ws.events.test.mjs"
 	},
 	"bugs": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -21,7 +21,8 @@
 	"scripts": {
 		"build": "rimraf ./dist && tsc",
 		"watch": "nodemon ./src/index.ts",
-		"test:ws": "node --test test/"
+		"test:ws": "node --test test/ws.integration.test.mjs test/ws.relay.test.mjs",
+		"test:ws:trade": "node --test test/ws.events.test.mjs"
 	},
 	"bugs": {
 		"url": "https://github.com/D8-X/d8x-trader-backend/issues"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -20,7 +20,8 @@
 	},
 	"scripts": {
 		"build": "rimraf ./dist && tsc",
-		"watch": "nodemon ./src/index.ts"
+		"watch": "nodemon ./src/index.ts",
+		"test:ws": "node --test test/"
 	},
 	"bugs": {
 		"url": "https://github.com/D8-X/d8x-trader-backend/issues"

--- a/packages/api/test/unit/relay.test.mjs
+++ b/packages/api/test/unit/relay.test.mjs
@@ -1,6 +1,8 @@
+process.env.REDIS_URL ??= "redis://localhost:6379";
+
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import EventListener from "../dist/eventListener.js";
+import EventListener from "../../dist/eventListener.js";
 
 const PID_NUM = 1;
 const PID_STR = "1";

--- a/packages/api/test/unit/resubscribe.test.mjs
+++ b/packages/api/test/unit/resubscribe.test.mjs
@@ -1,0 +1,36 @@
+process.env.REDIS_URL ??= "redis://localhost:6379";
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import EventListener from "../../dist/eventListener.js";
+
+const PID = 1;
+const SYM = "TEST-PERP";
+const TRADER = "0x1111111111111111111111111111111111111111";
+
+describe("resubscribe re-registers order-book listeners", () => {
+	test("subscribing again after the perp empties re-adds the listeners", () => {
+		const logger = { info() {}, warn() {}, error() {} };
+		const el = new EventListener(logger);
+		el.logger = logger;
+		el.traderInterface = { getPerpIdFromSymbol: () => PID, getSymbolFromPerpId: () => SYM };
+
+		let added = 0;
+		el.addOrderBookEventHandlers = () => {
+			added++;
+		};
+		el.removeOrderBookEventHandlers = () => {};
+
+		const ws1 = { send() {}, readyState: 1 };
+		const ws2 = { send() {}, readyState: 1 };
+		const req = { headers: {} };
+
+		el.subscribe(ws1, SYM, TRADER);
+		assert.equal(added, 1);
+
+		el.unsubscribe(ws1, req);
+		el.subscribe(ws2, SYM, TRADER);
+
+		assert.equal(added, 2, "order-book listeners were not re-registered on resubscribe");
+	});
+});

--- a/packages/api/test/ws.events.test.mjs
+++ b/packages/api/test/ws.events.test.mjs
@@ -13,7 +13,7 @@ const API_URL = process.env.API_URL_TESTNET;
 const RPC = process.env.RPC_TESTNET;
 const ORIGIN = process.env.WS_TEST_ORIGIN;
 const QTY = Number(process.env.TRADE_QTY);
-const TIMEOUT_MS = Number(process.env.TRADE_TEST_TIMEOUT_MS ?? 90000);
+const TIMEOUT_MS = Number(process.env.TRADE_TEST_TIMEOUT_MS ?? 120000);
 
 const skip =
 	!(PK && WS_URL && API_URL && RPC && QTY) &&
@@ -41,6 +41,15 @@ function connect(url) {
 	});
 }
 
+async function waitFor(fn, timeoutMs) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (fn()) return true;
+		await new Promise((r) => setTimeout(r, 1000));
+	}
+	return false;
+}
+
 describe("WS trade events — base sepolia", { skip }, () => {
 	let symbol, trader, accTrade;
 
@@ -54,7 +63,7 @@ describe("WS trade events — base sepolia", { skip }, () => {
 		await accTrade.createProxyInstance();
 	});
 
-	test("failing order is relayed: PerpetualLimitOrderCreated + ExecutionFailed", async () => {
+	test("placing an order relays PerpetualLimitOrderCreated to the trader", async () => {
 		const ws = await connect(WS_URL);
 		const received = new Map();
 		ws.on("message", (data) => {
@@ -70,7 +79,7 @@ describe("WS trade events — base sepolia", { skip }, () => {
 		ws.send(JSON.stringify({ traderAddr: trader, symbol }));
 		await new Promise((r) => setTimeout(r, 1500));
 
-		await accTrade.order({
+		const resp = await accTrade.order({
 			symbol,
 			side: "BUY",
 			type: "MARKET",
@@ -79,15 +88,19 @@ describe("WS trade events — base sepolia", { skip }, () => {
 			executionTimestamp: Math.floor(Date.now() / 1000),
 		});
 
-		const deadline = Date.now() + TIMEOUT_MS;
-		while (Date.now() < deadline) {
-			if (received.has("PerpetualLimitOrderCreated") && received.has("ExecutionFailed")) break;
-			await new Promise((r) => setTimeout(r, 1000));
+		assert.ok(
+			await waitFor(() => received.has("PerpetualLimitOrderCreated"), TIMEOUT_MS),
+			"PerpetualLimitOrderCreated not relayed",
+		);
+		const created = received.get("PerpetualLimitOrderCreated");
+		assert.equal(typeof created.perpetualId, "number");
+		assert.equal(created.traderAddr.toLowerCase(), trader.toLowerCase());
+
+		try {
+			await accTrade.cancelOrder(symbol, resp.orderId ?? resp.digest);
+		} catch {
+			// best-effort cleanup; order may already be filled
 		}
 		ws.close();
-
-		assert.ok(received.has("PerpetualLimitOrderCreated"), "PerpetualLimitOrderCreated not relayed");
-		assert.ok(received.has("ExecutionFailed"), "ExecutionFailed not relayed");
-		assert.equal(received.get("ExecutionFailed").traderAddr.toLowerCase(), trader.toLowerCase());
 	});
 });

--- a/packages/api/test/ws.events.test.mjs
+++ b/packages/api/test/ws.events.test.mjs
@@ -1,0 +1,93 @@
+import { test, describe, before } from "node:test";
+import assert from "node:assert/strict";
+import WebSocket from "ws";
+import { AccountTrade, PerpetualDataHandler } from "@d8-x/d8x-node-sdk";
+import { ethers } from "ethers";
+
+const SDK_CONFIG = "base_sepolia";
+const CHAIN_ID = 84532;
+
+const PK = process.env.KEY;
+const WS_URL = process.env.WS_URL_TESTNET;
+const API_URL = process.env.API_URL_TESTNET;
+const RPC = process.env.RPC_TESTNET;
+const ORIGIN = process.env.WS_TEST_ORIGIN;
+const QTY = Number(process.env.TRADE_QTY);
+const TIMEOUT_MS = Number(process.env.TRADE_TEST_TIMEOUT_MS ?? 90000);
+
+const skip =
+	!(PK && WS_URL && API_URL && RPC && QTY) &&
+	"set KEY, WS_URL_TESTNET, API_URL_TESTNET, RPC_TESTNET, TRADE_QTY";
+
+async function findActiveMarket(apiUrl) {
+	const res = await fetch(`${apiUrl.replace(/\/$/, "")}/exchange-info`, {
+		headers: ORIGIN ? { Origin: ORIGIN } : {},
+		signal: AbortSignal.timeout(30000),
+	});
+	const info = (await res.json()).data;
+	for (const pool of info.pools)
+		for (const p of pool.perpetuals)
+			if (p.state === "NORMAL" && !p.isMarketClosed)
+				return `${p.baseCurrency}-${p.quoteCurrency}-${pool.poolSymbol}`;
+	throw new Error("no active market found");
+}
+
+function connect(url) {
+	return new Promise((resolve, reject) => {
+		const ws = new WebSocket(url, ORIGIN ? { origin: ORIGIN } : {});
+		const to = setTimeout(() => (ws.terminate(), reject(new Error("connect timeout"))), 20000);
+		ws.once("open", () => (clearTimeout(to), resolve(ws)));
+		ws.once("error", (e) => (clearTimeout(to), reject(e)));
+	});
+}
+
+describe("WS trade events — base sepolia", { skip }, () => {
+	let symbol, trader, accTrade;
+
+	before(async () => {
+		const config = PerpetualDataHandler.readSDKConfig(SDK_CONFIG);
+		assert.equal(config.chainId, CHAIN_ID, "trade tests are restricted to base sepolia");
+		config.nodeURL = RPC;
+		trader = new ethers.Wallet(PK).address;
+		symbol = await findActiveMarket(API_URL);
+		accTrade = new AccountTrade(config, PK);
+		await accTrade.createProxyInstance();
+	});
+
+	test("failing order is relayed: PerpetualLimitOrderCreated + ExecutionFailed", async () => {
+		const ws = await connect(WS_URL);
+		const received = new Map();
+		ws.on("message", (data) => {
+			let m;
+			try {
+				m = JSON.parse(data.toString());
+			} catch {
+				return;
+			}
+			if (m.data?.name) received.set(m.data.name, m.data.obj);
+		});
+
+		ws.send(JSON.stringify({ traderAddr: trader, symbol }));
+		await new Promise((r) => setTimeout(r, 1500));
+
+		await accTrade.order({
+			symbol,
+			side: "BUY",
+			type: "MARKET",
+			quantity: QTY,
+			leverage: 10,
+			executionTimestamp: Math.floor(Date.now() / 1000),
+		});
+
+		const deadline = Date.now() + TIMEOUT_MS;
+		while (Date.now() < deadline) {
+			if (received.has("PerpetualLimitOrderCreated") && received.has("ExecutionFailed")) break;
+			await new Promise((r) => setTimeout(r, 1000));
+		}
+		ws.close();
+
+		assert.ok(received.has("PerpetualLimitOrderCreated"), "PerpetualLimitOrderCreated not relayed");
+		assert.ok(received.has("ExecutionFailed"), "ExecutionFailed not relayed");
+		assert.equal(received.get("ExecutionFailed").traderAddr.toLowerCase(), trader.toLowerCase());
+	});
+});

--- a/packages/api/test/ws.events.test.mjs
+++ b/packages/api/test/ws.events.test.mjs
@@ -19,9 +19,9 @@ const skip = !(PK && WS_URL && RPC) && "set KEY, WS_URL_TESTNET, RPC_TESTNET";
 function connect(url) {
 	return new Promise((resolve, reject) => {
 		const ws = new WebSocket(url, ORIGIN ? { origin: ORIGIN } : {});
-		const to = setTimeout(() => (ws.terminate(), reject(new Error("connect timeout"))), 20000);
+		const to = setTimeout(() => (ws.terminate(), reject(new Error("ws connect timeout"))), 20000);
 		ws.once("open", () => (clearTimeout(to), resolve(ws)));
-		ws.once("error", (e) => (clearTimeout(to), reject(e)));
+		ws.once("error", () => (clearTimeout(to), reject(new Error("ws connect error"))));
 	});
 }
 
@@ -34,7 +34,7 @@ async function waitFor(fn, timeoutMs) {
 	return false;
 }
 
-describe("WS trade events — base sepolia", { skip }, () => {
+describe("WS trade events base sepolia", { skip }, () => {
 	let symbol, trader, accTrade, failQty;
 
 	before(async () => {

--- a/packages/api/test/ws.events.test.mjs
+++ b/packages/api/test/ws.events.test.mjs
@@ -1,36 +1,20 @@
 import { test, describe, before } from "node:test";
 import assert from "node:assert/strict";
 import WebSocket from "ws";
-import { AccountTrade, PerpetualDataHandler } from "@d8-x/d8x-node-sdk";
+import { AccountTrade, MarketData, PerpetualDataHandler } from "@d8-x/d8x-node-sdk";
 import { ethers } from "ethers";
 
 const SDK_CONFIG = "base_sepolia";
 const CHAIN_ID = 84532;
+const LEVERAGE = 10;
 
 const PK = process.env.KEY;
 const WS_URL = process.env.WS_URL_TESTNET;
-const API_URL = process.env.API_URL_TESTNET;
 const RPC = process.env.RPC_TESTNET;
 const ORIGIN = process.env.WS_TEST_ORIGIN;
-const QTY = Number(process.env.TRADE_QTY);
 const TIMEOUT_MS = Number(process.env.TRADE_TEST_TIMEOUT_MS ?? 120000);
 
-const skip =
-	!(PK && WS_URL && API_URL && RPC && QTY) &&
-	"set KEY, WS_URL_TESTNET, API_URL_TESTNET, RPC_TESTNET, TRADE_QTY";
-
-async function findActiveMarket(apiUrl) {
-	const res = await fetch(`${apiUrl.replace(/\/$/, "")}/exchange-info`, {
-		headers: ORIGIN ? { Origin: ORIGIN } : {},
-		signal: AbortSignal.timeout(30000),
-	});
-	const info = (await res.json()).data;
-	for (const pool of info.pools)
-		for (const p of pool.perpetuals)
-			if (p.state === "NORMAL" && !p.isMarketClosed)
-				return `${p.baseCurrency}-${p.quoteCurrency}-${pool.poolSymbol}`;
-	throw new Error("no active market found");
-}
+const skip = !(PK && WS_URL && RPC) && "set KEY, WS_URL_TESTNET, RPC_TESTNET";
 
 function connect(url) {
 	return new Promise((resolve, reject) => {
@@ -51,19 +35,35 @@ async function waitFor(fn, timeoutMs) {
 }
 
 describe("WS trade events — base sepolia", { skip }, () => {
-	let symbol, trader, accTrade;
+	let symbol, trader, accTrade, failQty;
 
 	before(async () => {
 		const config = PerpetualDataHandler.readSDKConfig(SDK_CONFIG);
 		assert.equal(config.chainId, CHAIN_ID, "trade tests are restricted to base sepolia");
 		config.nodeURL = RPC;
 		trader = new ethers.Wallet(PK).address;
-		symbol = await findActiveMarket(API_URL);
+
+		const md = new MarketData(config);
+		await md.createProxyInstance();
+		const info = await md.exchangeInfo();
+		let price;
+		outer: for (const pool of info.pools)
+			for (const p of pool.perpetuals)
+				if (p.state === "NORMAL" && !p.isMarketClosed) {
+					symbol = `${p.baseCurrency}-${p.quoteCurrency}-${pool.poolSymbol}`;
+					price = p.markPrice;
+					break outer;
+				}
+		if (!symbol) throw new Error("no active market found");
+
+		const balance = await md.getWalletBalance(trader, symbol);
+		failQty = Math.ceil(((balance * LEVERAGE) / price) * 2);
+
 		accTrade = new AccountTrade(config, PK);
 		await accTrade.createProxyInstance();
 	});
 
-	test("placing an order relays PerpetualLimitOrderCreated to the trader", async () => {
+	test("margin-exceeding order relays PerpetualLimitOrderCreated then ExecutionFailed", async () => {
 		const ws = await connect(WS_URL);
 		const received = new Map();
 		ws.on("message", (data) => {
@@ -79,12 +79,12 @@ describe("WS trade events — base sepolia", { skip }, () => {
 		ws.send(JSON.stringify({ traderAddr: trader, symbol }));
 		await new Promise((r) => setTimeout(r, 1500));
 
-		const resp = await accTrade.order({
+		await accTrade.order({
 			symbol,
 			side: "BUY",
 			type: "MARKET",
-			quantity: QTY,
-			leverage: 10,
+			quantity: failQty,
+			leverage: LEVERAGE,
 			executionTimestamp: Math.floor(Date.now() / 1000),
 		});
 
@@ -92,15 +92,13 @@ describe("WS trade events — base sepolia", { skip }, () => {
 			await waitFor(() => received.has("PerpetualLimitOrderCreated"), TIMEOUT_MS),
 			"PerpetualLimitOrderCreated not relayed",
 		);
-		const created = received.get("PerpetualLimitOrderCreated");
-		assert.equal(typeof created.perpetualId, "number");
-		assert.equal(created.traderAddr.toLowerCase(), trader.toLowerCase());
-
-		try {
-			await accTrade.cancelOrder(symbol, resp.orderId ?? resp.digest);
-		} catch {
-			// best-effort cleanup; order may already be filled
-		}
+		assert.ok(
+			await waitFor(() => received.has("ExecutionFailed"), TIMEOUT_MS),
+			"ExecutionFailed not relayed",
+		);
+		const ef = received.get("ExecutionFailed");
+		assert.equal(typeof ef.perpetualId, "number");
+		assert.equal(ef.traderAddr.toLowerCase(), trader.toLowerCase());
 		ws.close();
 	});
 });

--- a/packages/api/test/ws.integration.test.mjs
+++ b/packages/api/test/ws.integration.test.mjs
@@ -47,10 +47,10 @@ function connect(url) {
 		const ws = new WebSocket(url, ORIGIN ? { origin: ORIGIN } : {});
 		const to = setTimeout(() => {
 			ws.terminate();
-			reject(new Error(`connect timeout: ${url}`));
+			reject(new Error("ws connect timeout"));
 		}, TIMEOUT_MS);
 		ws.once("open", () => (clearTimeout(to), resolve(ws)));
-		ws.once("error", (e) => (clearTimeout(to), reject(e)));
+		ws.once("error", () => (clearTimeout(to), reject(new Error("ws connect error"))));
 	});
 }
 
@@ -78,7 +78,7 @@ if (targets.length === 0) {
 }
 
 for (const t of targets) {
-	describe(`WS subscription — ${t.net} (${t.url})`, () => {
+	describe(`WS subscription ${t.net}`, () => {
 		let symbol = t.symbol;
 
 		before(async () => {

--- a/packages/api/test/ws.integration.test.mjs
+++ b/packages/api/test/ws.integration.test.mjs
@@ -5,29 +5,40 @@ import WebSocket from "ws";
 const TIMEOUT_MS = Number(process.env.WS_TEST_TIMEOUT_MS ?? 20000);
 const ORIGIN = process.env.WS_TEST_ORIGIN;
 const TRADER = process.env.WS_TEST_TRADER ?? "0x0000000000000000000000000000000000000001";
+const MAPPER_URL = process.env.GAME_MAPPER_URL;
+const MAPPER_KEY = process.env.GAME_MAPPER_API_KEY;
 
 const targets = Object.entries(process.env)
 	.filter(([k, v]) => k.startsWith("WS_URL_") && !!v)
 	.map(([k, v]) => {
 		const net = k.slice("WS_URL_".length);
-		return {
-			net,
-			url: v,
-			symbol: process.env[`SYMBOL_${net}`],
-			apiUrl: process.env[`API_URL_${net}`],
-		};
+		return { net, url: v, symbol: process.env[`SYMBOL_${net}`] };
 	});
 
-async function findActiveMarket(apiUrl) {
-	const res = await fetch(`${apiUrl.replace(/\/$/, "")}/exchange-info`, {
-		headers: ORIGIN ? { Origin: ORIGIN } : {},
-		signal: AbortSignal.timeout(TIMEOUT_MS),
-	});
-	const info = (await res.json()).data;
-	for (const pool of info.pools)
-		for (const p of pool.perpetuals)
-			if (p.state === "NORMAL" && !p.isMarketClosed)
-				return `${p.baseCurrency}-${p.quoteCurrency}-${pool.poolSymbol}`;
+async function findGameSymbol() {
+	if (!MAPPER_URL || !MAPPER_KEY) return undefined;
+	const rpc = (method, params) =>
+		fetch(MAPPER_URL, {
+			method: "POST",
+			headers: { "x-api-key": MAPPER_KEY, "content-type": "application/json" },
+			body: JSON.stringify({ jsonrpc: "2.0", method, params, id: 1 }),
+			signal: AbortSignal.timeout(TIMEOUT_MS),
+		})
+			.then((r) => r.json())
+			.then((j) => j.result);
+	try {
+		const today = new Date().toISOString().slice(0, 10);
+		const ymd = today.slice(2).replace(/-/g, "");
+		const status = await rpc("game_getStatus", {});
+		for (const league of Object.keys(status.leagues ?? {})) {
+			const games = await rpc("game_listGames", { league });
+			for (const g of games)
+				if (g.polymarket?.event_date === today)
+					return `${league}_${g.away_abbr}_${g.home_abbr}_${ymd}-PUSD-PUSD`;
+		}
+	} catch {
+		return undefined;
+	}
 	return undefined;
 }
 
@@ -71,7 +82,7 @@ for (const t of targets) {
 		let symbol = t.symbol;
 
 		before(async () => {
-			if (!symbol && t.apiUrl) symbol = await findActiveMarket(t.apiUrl);
+			if (!symbol) symbol = await findGameSymbol();
 		});
 
 		test("connects and greets with connect:success", async () => {
@@ -107,7 +118,7 @@ for (const t of targets) {
 		});
 
 		test("subscribe returns subscription + perpetual state", async (tc) => {
-			if (!symbol) return tc.skip(`set SYMBOL_${t.net} or API_URL_${t.net}`);
+			if (!symbol) return tc.skip(`set SYMBOL_${t.net} or GAME_MAPPER_URL/GAME_MAPPER_API_KEY`);
 			const ws = await connect(t.url);
 			try {
 				send(ws, { traderAddr: TRADER, symbol });
@@ -120,7 +131,7 @@ for (const t of targets) {
 		});
 
 		test("ping after subscribe returns pong", async (tc) => {
-			if (!symbol) return tc.skip(`set SYMBOL_${t.net} or API_URL_${t.net}`);
+			if (!symbol) return tc.skip(`set SYMBOL_${t.net} or GAME_MAPPER_URL/GAME_MAPPER_API_KEY`);
 			const ws = await connect(t.url);
 			try {
 				send(ws, { traderAddr: TRADER, symbol });
@@ -134,7 +145,7 @@ for (const t of targets) {
 		});
 
 		test("unsubscribe then resubscribe acks again", async (tc) => {
-			if (!symbol) return tc.skip(`set SYMBOL_${t.net} or API_URL_${t.net}`);
+			if (!symbol) return tc.skip(`set SYMBOL_${t.net} or GAME_MAPPER_URL/GAME_MAPPER_API_KEY`);
 			const ws = await connect(t.url);
 			try {
 				send(ws, { traderAddr: TRADER, symbol });

--- a/packages/api/test/ws.integration.test.mjs
+++ b/packages/api/test/ws.integration.test.mjs
@@ -1,18 +1,9 @@
-// WebSocket subscription integration tests.
-//
-// Per backend, set: WS_URL_<NET> and one of
-//   SYMBOL_<NET>   explicit perp symbol, or
-//   API_URL_<NET>  rest api base to auto-pick a live market from /exchange-info.
-// Optional: WS_TEST_ORIGIN (default https://predictex.com), WS_TEST_TRADER.
-//
-// Run: node --test test/
-
 import { test, describe, before } from "node:test";
 import assert from "node:assert/strict";
 import WebSocket from "ws";
 
 const TIMEOUT_MS = Number(process.env.WS_TEST_TIMEOUT_MS ?? 20000);
-const ORIGIN = process.env.WS_TEST_ORIGIN ?? "https://predictex.com";
+const ORIGIN = process.env.WS_TEST_ORIGIN;
 const TRADER = process.env.WS_TEST_TRADER ?? "0x0000000000000000000000000000000000000001";
 
 const targets = Object.entries(process.env)
@@ -27,10 +18,9 @@ const targets = Object.entries(process.env)
 		};
 	});
 
-// first NORMAL, open market from the backend's /exchange-info
 async function findActiveMarket(apiUrl) {
 	const res = await fetch(`${apiUrl.replace(/\/$/, "")}/exchange-info`, {
-		headers: { Origin: ORIGIN },
+		headers: ORIGIN ? { Origin: ORIGIN } : {},
 		signal: AbortSignal.timeout(TIMEOUT_MS),
 	});
 	const info = (await res.json()).data;
@@ -43,7 +33,7 @@ async function findActiveMarket(apiUrl) {
 
 function connect(url) {
 	return new Promise((resolve, reject) => {
-		const ws = new WebSocket(url, { origin: ORIGIN });
+		const ws = new WebSocket(url, ORIGIN ? { origin: ORIGIN } : {});
 		const to = setTimeout(() => {
 			ws.terminate();
 			reject(new Error(`connect timeout: ${url}`));
@@ -53,7 +43,6 @@ function connect(url) {
 	});
 }
 
-// resolve with the first parsed message matching `pred`
 function waitFor(ws, pred) {
 	return new Promise((resolve, reject) => {
 		const to = setTimeout(() => reject(new Error("timed out waiting for ws message")), TIMEOUT_MS);

--- a/packages/api/test/ws.integration.test.mjs
+++ b/packages/api/test/ws.integration.test.mjs
@@ -1,0 +1,163 @@
+// WebSocket subscription integration tests.
+//
+// Per backend, set: WS_URL_<NET> and one of
+//   SYMBOL_<NET>   explicit perp symbol, or
+//   API_URL_<NET>  rest api base to auto-pick a live market from /exchange-info.
+// Optional: WS_TEST_ORIGIN (default https://predictex.com), WS_TEST_TRADER.
+//
+// Run: node --test test/
+
+import { test, describe, before } from "node:test";
+import assert from "node:assert/strict";
+import WebSocket from "ws";
+
+const TIMEOUT_MS = Number(process.env.WS_TEST_TIMEOUT_MS ?? 20000);
+const ORIGIN = process.env.WS_TEST_ORIGIN ?? "https://predictex.com";
+const TRADER = process.env.WS_TEST_TRADER ?? "0x0000000000000000000000000000000000000001";
+
+const targets = Object.entries(process.env)
+	.filter(([k, v]) => k.startsWith("WS_URL_") && !!v)
+	.map(([k, v]) => {
+		const net = k.slice("WS_URL_".length);
+		return {
+			net,
+			url: v,
+			symbol: process.env[`SYMBOL_${net}`],
+			apiUrl: process.env[`API_URL_${net}`],
+		};
+	});
+
+// first NORMAL, open market from the backend's /exchange-info
+async function findActiveMarket(apiUrl) {
+	const res = await fetch(`${apiUrl.replace(/\/$/, "")}/exchange-info`, {
+		headers: { Origin: ORIGIN },
+		signal: AbortSignal.timeout(TIMEOUT_MS),
+	});
+	const info = (await res.json()).data;
+	for (const pool of info.pools)
+		for (const p of pool.perpetuals)
+			if (p.state === "NORMAL" && !p.isMarketClosed)
+				return `${p.baseCurrency}-${p.quoteCurrency}-${pool.poolSymbol}`;
+	return undefined;
+}
+
+function connect(url) {
+	return new Promise((resolve, reject) => {
+		const ws = new WebSocket(url, { origin: ORIGIN });
+		const to = setTimeout(() => {
+			ws.terminate();
+			reject(new Error(`connect timeout: ${url}`));
+		}, TIMEOUT_MS);
+		ws.once("open", () => (clearTimeout(to), resolve(ws)));
+		ws.once("error", (e) => (clearTimeout(to), reject(e)));
+	});
+}
+
+// resolve with the first parsed message matching `pred`
+function waitFor(ws, pred) {
+	return new Promise((resolve, reject) => {
+		const to = setTimeout(() => reject(new Error("timed out waiting for ws message")), TIMEOUT_MS);
+		const onMsg = (data) => {
+			let m;
+			try {
+				m = JSON.parse(data.toString());
+			} catch {
+				return;
+			}
+			if (pred(m)) (clearTimeout(to), ws.off("message", onMsg), resolve(m));
+		};
+		ws.on("message", onMsg);
+	});
+}
+
+const send = (ws, obj) => ws.send(JSON.stringify(obj));
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+if (targets.length === 0) {
+	test("skipped: no WS_URL_* env vars set", { skip: true }, () => {});
+}
+
+for (const t of targets) {
+	describe(`WS subscription — ${t.net} (${t.url})`, () => {
+		let symbol = t.symbol;
+
+		before(async () => {
+			if (!symbol && t.apiUrl) symbol = await findActiveMarket(t.apiUrl);
+		});
+
+		test("connects and greets with connect:success", async () => {
+			const ws = await connect(t.url);
+			try {
+				const m = await waitFor(ws, (m) => m.type === "connect");
+				assert.equal(m.msg, "success");
+			} finally {
+				ws.close();
+			}
+		});
+
+		test("rejects malformed trader address", async () => {
+			const ws = await connect(t.url);
+			try {
+				send(ws, { traderAddr: "not-an-address", symbol: "BTC-USD-USD" });
+				const m = await waitFor(ws, (m) => m.type === "error");
+				assert.equal(m.data.code, "SUBSCRIBE_ERROR");
+			} finally {
+				ws.close();
+			}
+		});
+
+		test("rejects unknown symbol", async () => {
+			const ws = await connect(t.url);
+			try {
+				send(ws, { traderAddr: TRADER, symbol: "NOTREAL-USD-USD" });
+				const m = await waitFor(ws, (m) => m.type === "error" || m.type === "subscription");
+				assert.equal(m.type, "error");
+			} finally {
+				ws.close();
+			}
+		});
+
+		test("subscribe returns subscription + perpetual state", async (tc) => {
+			if (!symbol) return tc.skip(`set SYMBOL_${t.net} or API_URL_${t.net}`);
+			const ws = await connect(t.url);
+			try {
+				send(ws, { traderAddr: TRADER, symbol });
+				const m = await waitFor(ws, (m) => m.type === "subscription");
+				assert.equal(m.msg, symbol.toUpperCase());
+				assert.equal(typeof m.data?.id, "number");
+			} finally {
+				ws.close();
+			}
+		});
+
+		test("ping after subscribe returns pong", async (tc) => {
+			if (!symbol) return tc.skip(`set SYMBOL_${t.net} or API_URL_${t.net}`);
+			const ws = await connect(t.url);
+			try {
+				send(ws, { traderAddr: TRADER, symbol });
+				await waitFor(ws, (m) => m.type === "subscription");
+				send(ws, { type: "ping" });
+				const m = await waitFor(ws, (m) => m.type === "ping");
+				assert.equal(m.msg, "pong");
+			} finally {
+				ws.close();
+			}
+		});
+
+		test("unsubscribe then resubscribe acks again", async (tc) => {
+			if (!symbol) return tc.skip(`set SYMBOL_${t.net} or API_URL_${t.net}`);
+			const ws = await connect(t.url);
+			try {
+				send(ws, { traderAddr: TRADER, symbol });
+				await waitFor(ws, (m) => m.type === "subscription");
+				send(ws, { type: "unsubscribe" });
+				await sleep(500);
+				send(ws, { traderAddr: TRADER, symbol });
+				const m = await waitFor(ws, (m) => m.type === "subscription");
+				assert.equal(m.msg, symbol.toUpperCase());
+			} finally {
+				ws.close();
+			}
+		});
+	});
+}

--- a/packages/api/test/ws.relay.test.mjs
+++ b/packages/api/test/ws.relay.test.mjs
@@ -1,0 +1,56 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import EventListener from "../dist/eventListener.js";
+
+const PID_NUM = 100012;
+const PID_STR = "100012";
+const SYM = "BTC-USD-USD";
+const TRADER = "0xeD7cAac542367a209126625e5E0B6272700216F5";
+const order = { flags: "0", iPerpetualId: PID_STR, traderAddr: TRADER };
+
+function makeListener() {
+	const logger = { info() {}, warn() {}, error() {} };
+	const el = new EventListener(logger);
+	el.logger = logger;
+	el.traderInterface = {
+		getPerpIdFromSymbol: () => PID_NUM,
+		getSymbolFromPerpId: (id) => (Number(id) === PID_NUM ? SYM : ""),
+	};
+	el.sdkInterface = el.traderInterface;
+	el.subscriptions.set(PID_NUM, new Map());
+	const got = [];
+	el.subscribe({ send: (m) => got.push(JSON.parse(m)), readyState: 1 }, SYM, TRADER);
+	return { el, got };
+}
+
+const last = (got) => got[got.length - 1];
+
+describe("EventListener relay with non-number perpetualId", () => {
+	test("ExecutionFailed delivered with numeric perpetualId", () => {
+		const { el, got } = makeListener();
+		el.onExecutionFailed(PID_STR, TRADER, "0xd1", "reason");
+		assert.equal(last(got).data.name, "ExecutionFailed");
+		assert.equal(typeof last(got).data.obj.perpetualId, "number");
+		assert.equal(last(got).data.obj.symbol, SYM);
+	});
+
+	test("PerpetualLimitOrderCreated delivered with numeric perpetualId", () => {
+		const { el, got } = makeListener();
+		el.onPerpetualLimitOrderCreated(PID_STR, TRADER, "0x0", order, "0xd2");
+		assert.equal(last(got).data.name, "PerpetualLimitOrderCreated");
+		assert.equal(typeof last(got).data.obj.perpetualId, "number");
+	});
+
+	test("Trade broadcast delivered with numeric perpetualId", () => {
+		const { el, got } = makeListener();
+		el.onTrade(PID_STR, TRADER, order, "0xd3", 0n, 0n);
+		assert.equal(last(got).data.name, "Trade");
+		assert.equal(typeof last(got).data.obj.perpetualId, "number");
+	});
+
+	test("onUpdateFundingRate keys the funding-rate map by number", () => {
+		const { el } = makeListener();
+		el.onUpdateFundingRate(PID_STR, 184467440737095516n);
+		assert.notEqual(el.fundingRate.get(PID_NUM), undefined);
+	});
+});

--- a/packages/api/test/ws.relay.test.mjs
+++ b/packages/api/test/ws.relay.test.mjs
@@ -2,10 +2,10 @@ import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import EventListener from "../dist/eventListener.js";
 
-const PID_NUM = 100012;
-const PID_STR = "100012";
-const SYM = "BTC-USD-USD";
-const TRADER = "0xeD7cAac542367a209126625e5E0B6272700216F5";
+const PID_NUM = 1;
+const PID_STR = "1";
+const SYM = "TEST-PERP";
+const TRADER = "0x1111111111111111111111111111111111111111";
 const order = { flags: "0", iPerpetualId: PID_STR, traderAddr: TRADER };
 
 function makeListener() {


### PR DESCRIPTION
We have silent bugs where WS events stopped reaching the frontend and nothing failed. These tests catch that.

- There are 4 unit tests in `test/unit/relay.test.mjs` that feed the event handler `perpetualId` the chain actually sends (the thing that caused the bug) and confirm `ExecutionFailed`, `PerpetualLimitOrderCreated` and `Trade` are still delivered to a subscriber
- There are 6 integration tests in `test/ws.integration.test.mjs` that are setup to talk to the  running testnet backend and walk through connect, subscribe, ping, bad input and unsub/resub. The test suite tests against a live market which it picks up from the /slots-info
- There is 1 end-to-end test in `test/ws.events.test.mjs` that places a real tiny testnet failing order and checks the backend actually relays `PerpetualLimitOrderCreated` and `ExecutionFailed`  (this does not run on every pr, it runs weekly as a sanity check), and can be manually triggered. 
