### PR TITLE
History service RPC usage

### DIFF
--- a/docker-compose-all.yml
+++ b/docker-compose-all.yml
@@ -60,6 +60,7 @@ services:
       dockerfile: ./packages/history/Dockerfile
     depends_on:
       - postgres
+      - redis
     environment:
       - DATABASE_DSN_HISTORY=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?schema=public
       - API_PORT=${HISTORY_API_PORT_HTTP}
@@ -68,6 +69,7 @@ services:
       - CORS_ON=${CORS_ON}
       - CONFIG_PATH_RPC=/cfg_rpc
       - CONFIG_PATH_REFERRAL_SETTINGS=/cfg_referral
+      - REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379/0
     ports:
       - "127.0.0.1:${HISTORY_API_PORT_HTTP}:${HISTORY_API_PORT_HTTP}"
     restart: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
             dockerfile: ./packages/history/Dockerfile
         depends_on:
             - postgres
+            - redis
         environment:
             - DATABASE_DSN_HISTORY=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?schema=public
             - API_PORT=${HISTORY_API_PORT_HTTP}
@@ -62,6 +63,7 @@ services:
             - CHAIN_ID=${CHAIN_ID}
             - CORS_ON=${CORS_ON}
             - CONFIG_PATH_RPC=/cfg_rpc
+            - REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379/0
         ports:
             - "127.0.0.1:${HISTORY_API_PORT_HTTP}:${HISTORY_API_PORT_HTTP}"
         restart: on-failure

--- a/packages/history/src/contracts/blockTimestampCache.ts
+++ b/packages/history/src/contracts/blockTimestampCache.ts
@@ -1,0 +1,38 @@
+const MAX_ENTRIES = 500_000;
+const cache = new Map<number, number>();
+
+let hits = 0;
+let misses = 0;
+
+export function getBlockTsCacheStats() {
+	return { hits, misses, size: cache.size, saved: hits };
+}
+
+export function getCachedBlockTs(blockNumber: number): number | undefined {
+	const v = cache.get(blockNumber);
+	if (v === undefined) {
+		misses++;
+	} else {
+		hits++;
+	}
+	return v;
+}
+
+export function setCachedBlockTs(blockNumber: number, timestamp: number): void {
+	if (cache.has(blockNumber)) {
+		return;
+	}
+	if (cache.size >= MAX_ENTRIES) {
+		const oldest = cache.keys().next().value;
+		if (oldest !== undefined) {
+			cache.delete(oldest);
+		}
+	}
+	cache.set(blockNumber, timestamp);
+}
+
+if (process.env.BLOCK_TS_CACHE_STATS === "true") {
+	setInterval(() => {
+		console.log(`[blockTsCacheStats] ${JSON.stringify(getBlockTsCacheStats())}`);
+	}, 30_000).unref();
+}

--- a/packages/history/src/contracts/historicalDataFilterer.ts
+++ b/packages/history/src/contracts/historicalDataFilterer.ts
@@ -32,6 +32,8 @@ import { getCachedBlockTs, setCachedBlockTs } from "./blockTimestampCache.js";
 
 global.Error.stackTraceLimit = Infinity;
 
+const END_BLOCK_MARGIN = 256;
+
 /**
  * HistoricalDataFilterer retrieves historical data for trades, liquidations and
  * other events from perpetual manager proxy contract
@@ -64,8 +66,18 @@ export class HistoricalDataFilterer {
 		shareTokenContracts: string[],
 		since: Array<Date>,
 		cb: P2PTransferFilteredCb,
+		until?: Date,
 	) {
 		const shareTokenAbi = await getShareTokenContractABI();
+		let untilBlock: number | undefined;
+		if (until) {
+			const untilBlocks: [number, number] = await executeWithTimeout(
+				calculateBlockFromTime(this.provider, until),
+				10_000,
+				"RPC call timeout",
+			);
+			untilBlock = untilBlocks[0] + END_BLOCK_MARGIN;
+		}
 		for (let i = 0; i < shareTokenContracts.length; i++) {
 			const currentAddress = shareTokenContracts[i];
 			this.l.info("starting p2p transfer filtering", {
@@ -98,7 +110,9 @@ export class HistoricalDataFilterer {
 						{ poolId },
 					);
 				},
-				sinceBlocks[1],
+				untilBlock !== undefined
+					? Math.min(sinceBlocks[1], untilBlock)
+					: sinceBlocks[1],
 			);
 		}
 	}
@@ -112,6 +126,7 @@ export class HistoricalDataFilterer {
 		since: Date,
 		callbacks: Record<string, EventCallback<any>>,
 		eventTimestamps?: Map<string, Date>,
+		until?: Date,
 	) {
 		const allEventNames = [
 			"Trade",
@@ -274,13 +289,23 @@ export class HistoricalDataFilterer {
 			10_000,
 			"RPC call timeout",
 		);
+
+		let endBlock = sinceBlocks[1];
+		if (until) {
+			const untilBlocks: [number, number] = await executeWithTimeout(
+				calculateBlockFromTime(this.provider, until),
+				10_000,
+				"RPC call timeout",
+			);
+			endBlock = Math.min(sinceBlocks[1], untilBlocks[0] + END_BLOCK_MARGIN);
+		}
 		await this.genericFilterer(
 			topicFilters!,
 			sinceBlocks[0],
 			topicHashes,
 			this.PerpManagerProxy,
 			cb,
-			sinceBlocks[1],
+			endBlock,
 		);
 
 		if (skipCounts.size > 0) {

--- a/packages/history/src/contracts/historicalDataFilterer.ts
+++ b/packages/history/src/contracts/historicalDataFilterer.ts
@@ -28,6 +28,7 @@ import {
 } from "ethers";
 import { getPerpetualManagerABI, getShareTokenContractABI } from "../utils/abi.js";
 import { metrics } from "../svc/metrics.js";
+import { getCachedBlockTs, setCachedBlockTs } from "./blockTimestampCache.js";
 
 global.Error.stackTraceLimit = Infinity;
 
@@ -434,14 +435,19 @@ export class HistoricalDataFilterer {
 						event.topics,
 					);
 					if (blockTimestamp.get(event.blockNumber) == undefined) {
+						const cachedTs = getCachedBlockTs(event.blockNumber);
+						if (cachedTs !== undefined) {
+							blockTimestamp.set(event.blockNumber, cachedTs);
+						}
+					}
+					if (blockTimestamp.get(event.blockNumber) == undefined) {
 						getBlockCalls++;
 						let retries = 0;
 						for (;;) {
 							try {
-								blockTimestamp.set(
-									event.blockNumber,
-									(await event.getBlock()).timestamp,
-								);
+								const blockTs = (await event.getBlock()).timestamp;
+								blockTimestamp.set(event.blockNumber, blockTs);
+								setCachedBlockTs(event.blockNumber, blockTs);
 								break;
 							} catch (e) {
 								if (isRateLimitError(e) && retries < 5) {

--- a/packages/history/src/contracts/listeners.ts
+++ b/packages/history/src/contracts/listeners.ts
@@ -28,6 +28,7 @@ import { LiquidityWithdrawals } from "../db/liquidity_withdrawals.js";
 import { SettleHistory } from "../db/settle_history.js";
 import { TokenFlow } from "../db/token_flow.js";
 import { metrics } from "../svc/metrics.js";
+import { getCachedBlockTs, setCachedBlockTs } from "./blockTimestampCache.js";
 export interface EventListenerOptions {
 	logger: Logger;
 	// smart contract addresses which will be used to listen to incoming events
@@ -84,7 +85,7 @@ export class EventListener {
 			return undefined;
 		}
 		const blockNum = event.log.blockNumber;
-		const cached = this.blockTsCache.get(blockNum);
+		const cached = this.blockTsCache.get(blockNum) ?? getCachedBlockTs(blockNum);
 		if (cached !== undefined) {
 			return cached;
 		}
@@ -95,6 +96,7 @@ export class EventListener {
 					this.blockTsCache.clear();
 				}
 				this.blockTsCache.set(blockNum, block.timestamp);
+				setCachedBlockTs(blockNum, block.timestamp);
 				return block.timestamp;
 			} catch (e) {
 				this.l.warn(`getBlockTs attempt ${attempt + 1}/3 failed`, {

--- a/packages/history/src/svc/backfillRunner.ts
+++ b/packages/history/src/svc/backfillRunner.ts
@@ -43,6 +43,7 @@ export async function runHistoricalDataFilterers(
 	opts: hdFilterersOpt,
 	startTimestampSec: number,
 	skipUpToDate = true,
+	endTimestampSec?: number,
 ) {
 	const {
 		httpProvider,
@@ -61,6 +62,8 @@ export async function runHistoricalDataFilterers(
 	} = opts;
 
 	const defaultDate = new Date(startTimestampSec * 1000);
+	const untilDate =
+		endTimestampSec !== undefined ? new Date(endTimestampSec * 1000) : undefined;
 	const hd = new HistoricalDataFilterer(httpProvider, proxyContractAddr, logger);
 
 	// Share token contracts
@@ -288,6 +291,7 @@ export async function runHistoricalDataFilterers(
 				},
 			},
 			skipUpToDate ? eventTimestamps : undefined,
+			untilDate,
 		),
 	);
 	// Share tokens p2p transfers
@@ -317,6 +321,7 @@ export async function runHistoricalDataFilterers(
 				staticInfo,
 			);
 		},
+		untilDate,
 	);
 	// align timestamps in perpetual_long_id (because we have asynchronous events)
 	await dbSetOracles.alignTimestamps();

--- a/packages/history/src/svc/gapMemory.ts
+++ b/packages/history/src/svc/gapMemory.ts
@@ -1,0 +1,56 @@
+import type { RedisClientType } from "redis";
+import type { Logger } from "winston";
+
+const GAP_TRIED_KEY = "history:gap:tried";
+const RETENTION_SEC = 30 * 24 * 3600;
+
+/**
+ * Remembers which gap windows we have already attempted to backfill.
+ * A connected Redis client is required
+ */
+export class GapMemory {
+	private client: RedisClientType;
+	private logger: Logger;
+
+	constructor(client: RedisClientType, logger: Logger) {
+		this.client = client;
+		this.logger = logger;
+	}
+
+	static key(gapStartSec: number, gapEndSec: number): string {
+		return `${gapStartSec}:${gapEndSec}`;
+	}
+
+	/** Whether this exact gap window has already been attempted. */
+	async hasTried(gapStartSec: number, gapEndSec: number): Promise<boolean> {
+		const score = await this.client.zScore(
+			GAP_TRIED_KEY,
+			GapMemory.key(gapStartSec, gapEndSec),
+		);
+		return score !== null;
+	}
+
+	/** Record that this gap window was attempted. */
+	async markTried(
+		gapStartSec: number,
+		gapEndSec: number,
+		nowSec: number,
+	): Promise<void> {
+		await this.client.zAdd(GAP_TRIED_KEY, {
+			score: nowSec,
+			value: GapMemory.key(gapStartSec, gapEndSec),
+		});
+	}
+
+	/** Drop attempts older than the retention window. */
+	async cleanup(nowSec: number): Promise<void> {
+		const removed = await this.client.zRemRangeByScore(
+			GAP_TRIED_KEY,
+			"-inf",
+			nowSec - RETENTION_SEC,
+		);
+		if (removed > 0) {
+			this.logger.info(`pruned ${removed} stale gap-attempt record(s)`);
+		}
+	}
+}

--- a/packages/history/src/svc/gaps.ts
+++ b/packages/history/src/svc/gaps.ts
@@ -26,7 +26,10 @@ export interface GapConfig {
 	thresholdSeconds: number;
 }
 
-export type BackfillRunner = (startTimestampSec: number) => Promise<void>;
+export type BackfillRunner = (
+	startTimestampSec: number,
+	endTimestampSec?: number,
+) => Promise<void>;
 
 export const GAP_CONFIGS: GapConfig[] = [
 	{
@@ -76,7 +79,7 @@ export async function detectAndFillGaps(
 	startTimestampSec: number,
 	logger: Logger,
 ): Promise<void> {
-	const allGapStarts = new Set<number>();
+	const gapWindows = new Map<number, number>();
 
 	for (const config of GAP_CONFIGS) {
 		try {
@@ -87,7 +90,13 @@ export async function detectAndFillGaps(
 					latest: `${gaps[gaps.length - 1].gap_start.toISOString()} - ${gaps[gaps.length - 1].gap_end.toISOString()}`,
 				});
 				for (const gap of gaps) {
-					allGapStarts.add(Math.floor(gap.gap_start.getTime() / 1000));
+					const startSec = Math.floor(gap.gap_start.getTime() / 1000);
+					const endSec = Math.ceil(gap.gap_end.getTime() / 1000);
+					const prev = gapWindows.get(startSec);
+					gapWindows.set(
+						startSec,
+						prev === undefined ? endSec : Math.max(prev, endSec),
+					);
 				}
 			}
 		} catch (e) {
@@ -98,19 +107,21 @@ export async function detectAndFillGaps(
 		}
 	}
 
-	if (allGapStarts.size === 0) return;
+	if (gapWindows.size === 0) return;
 
 	metrics.gapDetection.lastRun = new Date().toISOString();
-	metrics.gapDetection.gapsDetected = allGapStarts.size;
-	const sorted = [...allGapStarts].sort((a, b) => b - a);
+	metrics.gapDetection.gapsDetected = gapWindows.size;
+	const sorted = [...gapWindows.keys()].sort((a, b) => b - a);
 	logger.info(`filling ${sorted.length} unique gap(s), most recent first`);
 
 	for (const gapStartSec of sorted) {
 		const sec = Math.max(gapStartSec, startTimestampSec);
+		const endSec = gapWindows.get(gapStartSec)!;
 		logger.info("triggering backfill for gap", {
 			gap_start: new Date(sec * 1000).toISOString(),
+			gap_end: new Date(endSec * 1000).toISOString(),
 		});
-		await runBackfill(sec);
+		await runBackfill(sec, endSec);
 		metrics.gapDetection.gapsFilled++;
 	}
 }

--- a/packages/history/src/svc/gaps.ts
+++ b/packages/history/src/svc/gaps.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from "@prisma/client";
 import type { Logger } from "winston";
 import { metrics } from "./metrics.js";
+import { GapMemory } from "./gapMemory.js";
 
 export interface GapRow {
 	gap_start: Date;
@@ -78,7 +79,11 @@ export async function detectAndFillGaps(
 	runBackfill: BackfillRunner,
 	startTimestampSec: number,
 	logger: Logger,
+	gapMemory: GapMemory,
 ): Promise<void> {
+	const nowSec = Math.floor(Date.now() / 1000);
+	await gapMemory.cleanup(nowSec);
+
 	const gapWindows = new Map<number, number>();
 
 	for (const config of GAP_CONFIGS) {
@@ -117,10 +122,20 @@ export async function detectAndFillGaps(
 	for (const gapStartSec of sorted) {
 		const sec = Math.max(gapStartSec, startTimestampSec);
 		const endSec = gapWindows.get(gapStartSec)!;
+		if (await gapMemory.hasTried(gapStartSec, endSec)) {
+			logger.info("skipping gap already attempted", {
+				gap_start: new Date(gapStartSec * 1000).toISOString(),
+				gap_end: new Date(endSec * 1000).toISOString(),
+			});
+			metrics.gapDetection.gapsSkipped++;
+			continue;
+		}
 		logger.info("triggering backfill for gap", {
 			gap_start: new Date(sec * 1000).toISOString(),
 			gap_end: new Date(endSec * 1000).toISOString(),
 		});
+		// we record the attempt before running so a gap that crashes or persists is not rescanned every cycle
+		await gapMemory.markTried(gapStartSec, endSec, nowSec);
 		await runBackfill(sec, endSec);
 		metrics.gapDetection.gapsFilled++;
 	}

--- a/packages/history/src/svc/gaps.ts
+++ b/packages/history/src/svc/gaps.ts
@@ -122,9 +122,9 @@ export async function detectAndFillGaps(
 	for (const gapStartSec of sorted) {
 		const sec = Math.max(gapStartSec, startTimestampSec);
 		const endSec = gapWindows.get(gapStartSec)!;
-		if (await gapMemory.hasTried(gapStartSec, endSec)) {
+		if (await gapMemory.hasTried(sec, endSec)) {
 			logger.info("skipping gap already attempted", {
-				gap_start: new Date(gapStartSec * 1000).toISOString(),
+				gap_start: new Date(sec * 1000).toISOString(),
 				gap_end: new Date(endSec * 1000).toISOString(),
 			});
 			metrics.gapDetection.gapsSkipped++;
@@ -135,7 +135,7 @@ export async function detectAndFillGaps(
 			gap_end: new Date(endSec * 1000).toISOString(),
 		});
 		// we record the attempt before running so a gap that crashes or persists is not rescanned every cycle
-		await gapMemory.markTried(gapStartSec, endSec, nowSec);
+		await gapMemory.markTried(sec, endSec, nowSec);
 		await runBackfill(sec, endSec);
 		metrics.gapDetection.gapsFilled++;
 	}

--- a/packages/history/src/svc/main.ts
+++ b/packages/history/src/svc/main.ts
@@ -1,6 +1,11 @@
 import { EventListener } from "../contracts/listeners.js";
 import * as dotenv from "dotenv";
-import { chooseRandomRPC, executeWithTimeout, loadConfigRPC } from "utils";
+import {
+	chooseRandomRPC,
+	constructRedis,
+	executeWithTimeout,
+	loadConfigRPC,
+} from "utils";
 import { logger } from "./logger.js";
 import {
 	isRateLimitError,
@@ -26,6 +31,7 @@ import { SettleHistory } from "../db/settle_history.js";
 import { TokenFlow } from "../db/token_flow.js";
 import { metrics } from "./metrics.js";
 import { detectAndFillGaps } from "./gaps.js";
+import { GapMemory } from "./gapMemory.js";
 import { hdFilterersOpt, runHistoricalDataFilterers } from "./backfillRunner.js";
 import sturdyWebsocket from "sturdy-websocket";
 const SturdyWebSocket = sturdyWebsocket.default;
@@ -53,6 +59,7 @@ export const loadEnv = (wantEnvs?: string[] | undefined) => {
 		"SDK_CONFIG_NAME",
 		"CHAIN_ID",
 		"HISTORY_API_PORT_HTTP",
+		"REDIS_URL",
 	];
 	required.forEach((e) => {
 		if (!(e in process.env)) {
@@ -181,6 +188,18 @@ export const main = async () => {
 		logger,
 	};
 
+	const redisClient = constructRedis("history-gaps");
+	try {
+		await redisClient.connect();
+	} catch (e) {
+		logger.error("gap memory: could not connect to redis", {
+			error: formatErrorMessage(e),
+		});
+		process.exit(1);
+	}
+	const gapMemory = new GapMemory(redisClient, logger);
+	logger.info("gap memory: connected to redis");
+
 	let backfillRunning = false;
 	const runBackfillGuarded = async (startSec: number, skipUpToDate = true) => {
 		if (backfillRunning) {
@@ -209,6 +228,7 @@ export const main = async () => {
 					runHistoricalDataFilterers(hdOpts, sec, false, endSec),
 				sevenDaysAgoSec,
 				logger,
+				gapMemory,
 			);
 		})
 		.catch((e) => {
@@ -341,6 +361,7 @@ export const main = async () => {
 					runHistoricalDataFilterers(hdOpts, sec, false, endSec),
 				blk.timestamp,
 				logger,
+				gapMemory,
 			);
 		} catch (e) {
 			logger.warn("gap detection failed", { error: formatErrorMessage(e) });

--- a/packages/history/src/svc/main.ts
+++ b/packages/history/src/svc/main.ts
@@ -205,7 +205,8 @@ export const main = async () => {
 			const sevenDaysAgoSec = Math.floor(Date.now() / 1000) - 7 * 24 * 3600;
 			return detectAndFillGaps(
 				prisma,
-				(sec: number) => runHistoricalDataFilterers(hdOpts, sec, false),
+				(sec: number, endSec?: number) =>
+					runHistoricalDataFilterers(hdOpts, sec, false, endSec),
 				sevenDaysAgoSec,
 				logger,
 			);
@@ -336,7 +337,8 @@ export const main = async () => {
 		try {
 			await detectAndFillGaps(
 				prisma,
-				(sec: number) => runHistoricalDataFilterers(hdOpts, sec, false),
+				(sec: number, endSec?: number) =>
+					runHistoricalDataFilterers(hdOpts, sec, false, endSec),
 				blk.timestamp,
 				logger,
 			);

--- a/packages/history/src/svc/metrics.ts
+++ b/packages/history/src/svc/metrics.ts
@@ -31,6 +31,7 @@ export const metrics = {
 	gapDetection: {
 		gapsDetected: 0,
 		gapsFilled: 0,
+		gapsSkipped: 0,
 		lastRun: null as string | null,
 	},
 	eventsProcessed: {} as Record<string, number>,


### PR DESCRIPTION
- Limited the gaps data fill to exactly the detected gap's time window. 
- Made the history service write in Redis the gaps that it already tried to fill in previous backfills of gaps.
- Avoid getBlockTs(event) to fetch the ts if we have already fetched it for that same block in an another event listener or in the data backfill. 